### PR TITLE
Adding ibmq_16_melbourne to the devices' public names list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### 🎉 Added
+- Adding new device ibmq_16_melbourne to the list of devices ([#34](https://github.com/Qiskit/qiskit-vscode/pull/34) by [@cbjuan](https://github.com/cbjuan))
 
 ### 🐛 Fixed
 

--- a/client/resources/qiskitScripts/listRemoteBackends.py
+++ b/client/resources/qiskitScripts/listRemoteBackends.py
@@ -13,6 +13,7 @@ from multiprocessing import Pool
 PUBLIC_NAMES = {
     'ibmq_20_tokyo': 'IBM Q 20 Tokyo',
     'QS1_1': 'IBM Q 20 Austin',
+    'ibmq_16_melbourne': 'IBM Q 16 Melbourne',
     'ibmqx5': 'IBM Q 16 Rueschlikon',
     'ibmq_16_rueschlikon': 'IBM Q 16 Rueschlikon',
     'ibmqx4': 'IBM Q 5 Tenerife',


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG.md file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have read the CONTRIBUTING.md document.
-->

### Summary
As reported in #33, the action/button to get `IBMQ devices status` fails since the release last Friday (2018/09/21) of the chip 'IBM Q 16 Melbourne'. This PR fixes that issue by including the new chip in the list of public devices.

### Details and comments


