### PR TITLE
Fix related to issue 40: a package must be only updated when the user accepts the modal dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### 🎉 Added
 
 ### 🐛 Fixed
+- Changing update packages modal behavior: they must be only updated if the user clicks OK explicitly ([#45](https://github.com/Qiskit/qiskit-vscode/pull/45) by [@cbjuan](https://github.com/cbjuan))
 
 ### ✏️ Changed
 

--- a/client/src/packages/packageManager.ts
+++ b/client/src/packages/packageManager.ts
@@ -126,8 +126,8 @@ export class PackageManager {
             QLogger.verbose(`Clicked on Dismiss!`, this);
             return false;
         } else {
-            QLogger.verbose(`Clicked on other element! Updating anyway...`, this);
-            return true;
+            QLogger.verbose(`Clicked on another element! Cancelling update`, this);
+            return false;
         }
     }
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG.md file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have read the CONTRIBUTING.md document.
-->

### Summary
Related to #40, when the users click on any other element rather than "Dismiss" button in the modal dialog that offers the users the update of pypi packages the extension updates it. For example, when a user clicks on closing the modal, the package is updated as the user does not click on "dismiss".

This PR fixes that.

### Details and comments
From now, the package offered will be only updated if the user clicks on the 'Ok' button explicitly.

