### PR TITLE
Fix snippets for Qiskit Aqua >=v0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### ✏️ Changed
 
+-   Updating the support of snippets related to Qiskit Aqua to version v0.3 ([#49](https://github.com/Qiskit/qiskit-vscode/pull/49) by [@cbjuan](https://github.com/cbjuan))
+
 ### 👾 Security
 
 ## [v0.3.6] - 2018-10-25

--- a/client/package.json
+++ b/client/package.json
@@ -92,8 +92,8 @@
 					"type": "object",
 					"default": {
 						"qiskit": "0.5.4",
-						"qiskit-aqua": "0.2.0",
-						"qiskit-aqua-chemistry": "0.2.0"
+						"qiskit-aqua": "0.3.0",
+						"qiskit-aqua-chemistry": "0.3.0"
 					},
 					"description": "Qiskit and libraries related to run code"
 				},

--- a/client/snippets/aqua.json
+++ b/client/snippets/aqua.json
@@ -2,11 +2,11 @@
     "import": {
         "prefix": "import",
         "body": [ 
-            "from qiskit_acqua import run_algorithm",
-            "from qiskit_acqua.input import get_input_instance",
-            "from qiskit_acqua.ising import partition" 
+            "from qiskit_aqua import run_algorithm",
+            "from qiskit_aqua.input import get_input_instance",
+            "from qiskit_aqua.ising import partition" 
         ],
-        "description": "Code snippet for the basic Acqua imports"
+        "description": "Code snippet for the basic imports in Qiskit Aqua"
     },
     "input_partition": {
         "prefix": "input_partition",
@@ -15,7 +15,7 @@
             "${2:input} = get_input_instance('EnergyInput')",
             "${2:input}.qubit_op = qubitOp"
         ],
-        "description": "Code snippet for a partition problem input"
+        "description": "Code snippet for a partition problem input using Qiskit Aqua"
     },
     "grover": {
         "prefix": "grover",
@@ -29,7 +29,7 @@
             "",
             "${4:result} = run_algorithm(${1:params})"
         ],
-        "description": "Code snippet for the Grover algorithm"
+        "description": "Code snippet for the Grover algorithm using Qiskit Aqua"
     },
     "vqe": {
         "prefix": "vqe",
@@ -44,7 +44,7 @@
             "",
             "${3:result} = run_algorithm(${1:params}, ${4:input})"
         ],
-        "description": "Code snippet for the Grover algorithm"
+        "description": "Code snippet for the Grover algorithm using Qiskit Aqua"
     },
     "print_eigensolver_result": {
         "prefix": "print_eigensolver_result",
@@ -56,6 +56,6 @@
             "print('solution:', x)",
             "print('solution objective:', partition.partition_value(x, number_list))"
         ],
-        "description": "Code snippet to print an Eigensolver solution"
+        "description": "Code snippet to print an Eigensolver solution using Qiskit Aqua"
     }
 }

--- a/client/snippets/aqua.json
+++ b/client/snippets/aqua.json
@@ -4,7 +4,7 @@
         "body": [ 
             "from qiskit_aqua import run_algorithm",
             "from qiskit_aqua.input import get_input_instance",
-            "from qiskit_aqua.ising import partition" 
+            "from qiskit_aqua.translators.ising import partition" 
         ],
         "description": "Code snippet for the basic imports in Qiskit Aqua"
     },
@@ -49,7 +49,7 @@
     "print_eigensolver_result": {
         "prefix": "print_eigensolver_result",
         "body": [
-            "x = partition.sample_most_likely(len(number_list), ${1:result}['eigvecs'][0])",
+            "x = partition.sample_most_likely(${1:result}['eigvecs'][0])",
             "print('energy:', ${1:result}['energy'])",
             "print('time:', ${1:result}['eval_time'])",
             "print('partition objective:', ${1:result}['energy'] + offset)",


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG.md file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have read the CONTRIBUTING.md document.
-->

### Summary
As explained in issue #48, the current snippets error with the current version v0.3 of Qiskit Aqua and Aqua Chemistry.

This PR updates the snippets and the required packages to use only `qiskit-aqua` and `qiskit-aqua-chemistry` >=v0.3


### Details and comments
This PR removes the compatibility of the extension's snippets with Qiskit Aqua and Aqua Chemistry < v0.3. Also, from now, Qiskit-vscode will try to install these libraries using version >=0.3

