### PR TITLE
Adding support for Qiskit Terra 0.7. Dropping support for Qiskit Terra v0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### 🎉 Added
 
+-   Adding the support for Qiskit Terra v0.7.X ([#61](https://github.com/Qiskit/qiskit-vscode/pull/61) by [@cbjuan](https://github.com/cbjuan))
+
 ### 🐛 Fixed
 
 ### ✏️ Changed
@@ -26,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### ❌ Removed
 
--   Removing the support for Qiskit Terra v0.5.X
+-   Removing the support for Qiskit Terra v0.5.X ([#61](https://github.com/Qiskit/qiskit-vscode/pull/61) by [@cbjuan](https://github.com/cbjuan))
 
 ## [v0.4.1] - 2018-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,7 +291,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   Extension size reduction ([#76](https://github.ibm.com/IBMQuantum/qiskit-vscode/pull/76) by [@ydarias](https://github.com/ydarias))
 
 [unreleased]: https://github.com/Qiskit/qiskit-vscode/compare/v0.4.1...HEAD
-[v0.4.0]: https://github.com/Qiskit/qiskit-vscode/compare/v0.4.0...v0.4.1
+[v0.4.1]: https://github.com/Qiskit/qiskit-vscode/compare/v0.4.0...v0.4.1
 [v0.4.0]: https://github.com/Qiskit/qiskit-vscode/compare/v0.3.6...v0.4.0
 [v0.3.6]: https://github.com/Qiskit/qiskit-vscode/compare/v0.3.5...v0.3.6
 [v0.3.5]: https://github.com/Qiskit/qiskit-vscode/compare/v0.3.4...v0.3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### 👾 Security
 
+### ❌ Removed
+
+-   Removing the support for Qiskit Terra v0.5.X
+
 ## [v0.4.1] - 2018-11-05
 
 ### 🎉 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### 🎉 Added
 
--   Adding the support for Qiskit Terra v0.7.X ([#61](https://github.com/Qiskit/qiskit-vscode/pull/61) by [@cbjuan](https://github.com/cbjuan))
+-   Adding support for Qiskit Terra v0.7.X ([#61](https://github.com/Qiskit/qiskit-vscode/pull/61) by [@cbjuan](https://github.com/cbjuan))
 
 ### 🐛 Fixed
 
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### ❌ Removed
 
--   Removing the support for Qiskit Terra v0.5.X ([#61](https://github.com/Qiskit/qiskit-vscode/pull/61) by [@cbjuan](https://github.com/cbjuan))
+-   Removing support for Qiskit Terra v0.5.X ([#61](https://github.com/Qiskit/qiskit-vscode/pull/61) by [@cbjuan](https://github.com/cbjuan))
 
 ## [v0.4.1] - 2018-11-05
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We encourage you to visit [https://qiskit.org/](https://qiskit.org/) to explore 
 
 ## Feature details
 
--   Support [Qiskit Terra](https://github.com/Qiskit/qiskit-terra/) versions v0.5.X and v0.6.X.
+-   Support [Qiskit Terra](https://github.com/Qiskit/qiskit-terra/) version v0.6.X.
 -   Check necessary dependencies to execute OpenQASM or Qiskit files.
 -   Run Qiskit source code in a backend.
 -   Run OpenQASM source code in a local backend.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We encourage you to visit [https://qiskit.org/](https://qiskit.org/) to explore 
 
 ## Feature details
 
--   Support [Qiskit Terra](https://github.com/Qiskit/qiskit-terra/) version v0.6.X.
+-   Support [Qiskit Terra](https://github.com/Qiskit/qiskit-terra/) version v0.6.X and v0.7.X.
 -   Check necessary dependencies to execute OpenQASM or Qiskit files.
 -   Run Qiskit source code in a backend.
 -   Run OpenQASM source code in a local backend.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -10,7 +10,7 @@
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "7.0.0"
 			}
 		},
 		"@babel/highlight": {
@@ -19,9 +19,9 @@
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^4.0.0"
+				"chalk": "2.4.1",
+				"esutils": "2.0.2",
+				"js-tokens": "4.0.0"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -38,7 +38,7 @@
 			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
 			"dev": true,
 			"requires": {
-				"any-observable": "^0.3.0"
+				"any-observable": "0.3.0"
 			}
 		},
 		"@types/jest": {
@@ -82,8 +82,8 @@
 			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
+				"acorn": "6.0.4",
+				"acorn-walk": "6.1.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -106,10 +106,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ansi-cyan": {
@@ -147,7 +147,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.3"
 			}
 		},
 		"ansi-wrap": {
@@ -167,8 +167,8 @@
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -186,16 +186,16 @@
 					"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -203,7 +203,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -221,13 +221,13 @@
 					"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -235,7 +235,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -243,7 +243,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -251,7 +251,7 @@
 							"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -259,7 +259,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -269,7 +269,7 @@
 							"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -277,7 +277,7 @@
 									"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -287,9 +287,9 @@
 							"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -304,8 +304,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -313,7 +313,7 @@
 							"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"requires": {
-								"is-plain-object": "^2.0.4"
+								"is-plain-object": "2.0.4"
 							}
 						}
 					}
@@ -323,14 +323,14 @@
 					"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -338,7 +338,7 @@
 							"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -346,7 +346,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -356,10 +356,10 @@
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -367,7 +367,7 @@
 							"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -377,7 +377,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -385,7 +385,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -393,9 +393,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -403,7 +403,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -411,7 +411,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -431,19 +431,19 @@
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				}
 			}
@@ -454,7 +454,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^1.0.0"
+				"default-require-extensions": "1.0.0"
 			}
 		},
 		"argparse": {
@@ -463,7 +463,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -472,8 +472,8 @@
 			"integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.0.1",
-				"array-slice": "^0.2.3"
+				"arr-flatten": "1.1.0",
+				"array-slice": "0.2.3"
 			}
 		},
 		"arr-flatten": {
@@ -511,7 +511,7 @@
 			"integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
 			"dev": true,
 			"requires": {
-				"array-uniq": "^1.0.1"
+				"array-uniq": "1.0.3"
 			}
 		},
 		"array-uniq": {
@@ -570,7 +570,7 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "4.17.11"
 			}
 		},
 		"async-each": {
@@ -614,9 +614,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -631,11 +631,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"supports-color": {
@@ -652,25 +652,25 @@
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.5.1",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.11",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -696,14 +696,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.11",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -720,8 +720,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-jest": {
@@ -730,8 +730,8 @@
 			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.6",
-				"babel-preset-jest": "^23.2.0"
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-preset-jest": "23.2.0"
 			}
 		},
 		"babel-messages": {
@@ -740,7 +740,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -749,10 +749,10 @@
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.10.2",
+				"test-exclude": "4.2.3"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -773,8 +773,8 @@
 			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^23.2.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"babel-plugin-jest-hoist": "23.2.0",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
 			}
 		},
 		"babel-register": {
@@ -783,13 +783,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.3",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.7",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.11",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			},
 			"dependencies": {
 				"source-map": {
@@ -804,7 +804,7 @@
 					"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 					"dev": true,
 					"requires": {
-						"source-map": "^0.5.6"
+						"source-map": "0.5.7"
 					}
 				}
 			}
@@ -815,8 +815,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.7",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"babel-template": {
@@ -825,11 +825,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-traverse": {
@@ -838,15 +838,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.11"
 			},
 			"dependencies": {
 				"debug": {
@@ -866,10 +866,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.11",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -888,13 +888,13 @@
 			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -902,7 +902,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -910,7 +910,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -918,7 +918,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -926,9 +926,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -950,7 +950,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"binary-extensions": {
@@ -965,7 +965,7 @@
 			"integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.0"
+				"inherits": "2.0.3"
 			}
 		},
 		"brace-expansion": {
@@ -973,7 +973,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -983,9 +983,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.2"
 			}
 		},
 		"browser-process-hrtime": {
@@ -1015,7 +1015,7 @@
 			"integrity": "sha512-uFLE0LFMxrH8Z5Hd9QgivvRbrl/NFkOTHzGhlqQxsnmx5JBLrp4bc249afLL+GccyY/8hkcGi2LpVaOzaEY0nQ==",
 			"dev": true,
 			"requires": {
-				"fast-json-stable-stringify": "^2.0.0"
+				"fast-json-stable-stringify": "2.0.0"
 			}
 		},
 		"bser": {
@@ -1024,7 +1024,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer-crc32": {
@@ -1050,15 +1050,15 @@
 			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -1085,7 +1085,7 @@
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
 			"requires": {
-				"rsvp": "^3.3.3"
+				"rsvp": "3.6.2"
 			}
 		},
 		"caseless": {
@@ -1099,12 +1099,12 @@
 			"resolved": "https://registry.npmjs.org/chai/-/chai-4.2.0.tgz",
 			"integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
 			"requires": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.2",
-				"deep-eql": "^3.0.1",
-				"get-func-name": "^2.0.0",
-				"pathval": "^1.1.0",
-				"type-detect": "^4.0.5"
+				"assertion-error": "1.1.0",
+				"check-error": "1.0.2",
+				"deep-eql": "3.0.1",
+				"get-func-name": "2.0.0",
+				"pathval": "1.1.0",
+				"type-detect": "4.0.8"
 			}
 		},
 		"chalk": {
@@ -1113,9 +1113,9 @@
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.5.0"
 			}
 		},
 		"check-error": {
@@ -1129,19 +1129,19 @@
 			"integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
 			"optional": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"async-each": "^1.0.0",
-				"braces": "^2.3.0",
-				"fsevents": "^1.2.2",
-				"glob-parent": "^3.1.0",
-				"inherits": "^2.0.1",
-				"is-binary-path": "^1.0.0",
-				"is-glob": "^4.0.0",
-				"lodash.debounce": "^4.0.8",
-				"normalize-path": "^2.1.1",
-				"path-is-absolute": "^1.0.0",
-				"readdirp": "^2.0.0",
-				"upath": "^1.0.5"
+				"anymatch": "2.0.0",
+				"async-each": "1.0.1",
+				"braces": "2.3.2",
+				"fsevents": "1.2.4",
+				"glob-parent": "3.1.0",
+				"inherits": "2.0.3",
+				"is-binary-path": "1.0.1",
+				"is-glob": "4.0.0",
+				"lodash.debounce": "4.0.8",
+				"normalize-path": "2.1.1",
+				"path-is-absolute": "1.0.1",
+				"readdirp": "2.1.0",
+				"upath": "1.1.0"
 			},
 			"dependencies": {
 				"array-unique": {
@@ -1156,16 +1156,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"optional": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					}
 				},
 				"extend-shallow": {
@@ -1173,7 +1173,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"fill-range": {
@@ -1182,10 +1182,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"optional": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					}
 				},
 				"is-glob": {
@@ -1194,7 +1194,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"optional": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"is-number": {
@@ -1203,7 +1203,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"optional": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"isobject": {
@@ -1218,7 +1218,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"optional": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -1234,10 +1234,10 @@
 			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"arr-union": {
@@ -1250,7 +1250,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"isobject": {
@@ -1266,7 +1266,7 @@
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^1.0.1"
+				"restore-cursor": "1.0.1"
 			}
 		},
 		"cli-truncate": {
@@ -1276,7 +1276,7 @@
 			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
+				"string-width": "1.0.2"
 			}
 		},
 		"cliui": {
@@ -1284,9 +1284,9 @@
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
 			"integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1",
+				"wrap-ansi": "2.1.0"
 			}
 		},
 		"clone": {
@@ -1313,9 +1313,9 @@
 			"integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"process-nextick-args": "^2.0.0",
-				"readable-stream": "^2.3.5"
+				"inherits": "2.0.3",
+				"process-nextick-args": "2.0.0",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"co": {
@@ -1334,8 +1334,8 @@
 			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color": {
@@ -1343,8 +1343,8 @@
 			"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
 			"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
 			"requires": {
-				"color-convert": "^1.9.1",
-				"color-string": "^1.5.2"
+				"color-convert": "1.9.3",
+				"color-string": "1.5.3"
 			}
 		},
 		"color-convert": {
@@ -1365,8 +1365,8 @@
 			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
 			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
 			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
+				"color-name": "1.1.3",
+				"simple-swizzle": "0.2.2"
 			}
 		},
 		"colornames": {
@@ -1384,8 +1384,8 @@
 			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
 			"integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
 			"requires": {
-				"color": "3.0.x",
-				"text-hex": "1.0.x"
+				"color": "3.0.0",
+				"text-hex": "1.0.0"
 			}
 		},
 		"combined-stream": {
@@ -1394,7 +1394,7 @@
 			"integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -1441,9 +1441,9 @@
 			"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
 			"dev": true,
 			"requires": {
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
-				"parse-json": "^4.0.0"
+				"is-directory": "0.3.1",
+				"js-yaml": "3.12.0",
+				"parse-json": "4.0.0"
 			},
 			"dependencies": {
 				"parse-json": {
@@ -1452,8 +1452,8 @@
 					"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.3.1",
-						"json-parse-better-errors": "^1.0.1"
+						"error-ex": "1.3.2",
+						"json-parse-better-errors": "1.0.2"
 					}
 				}
 			}
@@ -1464,9 +1464,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.3",
+				"shebang-command": "1.2.0",
+				"which": "1.3.1"
 			}
 		},
 		"cssom": {
@@ -1481,7 +1481,7 @@
 			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "0.3.4"
 			}
 		},
 		"dashdash": {
@@ -1490,7 +1490,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"data-urls": {
@@ -1499,9 +1499,9 @@
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "2.0.0",
+				"whatwg-mimetype": "2.2.0",
+				"whatwg-url": "7.0.0"
 			},
 			"dependencies": {
 				"whatwg-url": {
@@ -1510,9 +1510,9 @@
 					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
 					"dev": true,
 					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
+						"lodash.sortby": "4.7.0",
+						"tr46": "1.0.1",
+						"webidl-conversions": "4.0.2"
 					}
 				}
 			}
@@ -1553,7 +1553,7 @@
 			"integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
 			"dev": true,
 			"requires": {
-				"is-obj": "^1.0.0"
+				"is-obj": "1.0.1"
 			}
 		},
 		"deep-eql": {
@@ -1561,7 +1561,7 @@
 			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
 			"integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
 			"requires": {
-				"type-detect": "^4.0.0"
+				"type-detect": "4.0.8"
 			}
 		},
 		"deep-equal": {
@@ -1581,7 +1581,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "^2.0.0"
+				"strip-bom": "2.0.0"
 			}
 		},
 		"define-properties": {
@@ -1590,7 +1590,7 @@
 			"integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
 			"dev": true,
 			"requires": {
-				"object-keys": "^1.0.12"
+				"object-keys": "1.0.12"
 			}
 		},
 		"define-property": {
@@ -1598,8 +1598,8 @@
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -1607,7 +1607,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1615,7 +1615,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1623,9 +1623,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -1652,7 +1652,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-newline": {
@@ -1666,9 +1666,9 @@
 			"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
 			"integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
 			"requires": {
-				"colorspace": "1.1.x",
-				"enabled": "1.0.x",
-				"kuler": "1.0.x"
+				"colorspace": "1.1.1",
+				"enabled": "1.0.2",
+				"kuler": "1.0.1"
 			}
 		},
 		"diff": {
@@ -1683,7 +1683,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"duplexer": {
@@ -1698,10 +1698,10 @@
 			"integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
 			"dev": true,
 			"requires": {
-				"end-of-stream": "^1.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.0",
-				"stream-shift": "^1.0.0"
+				"end-of-stream": "1.4.1",
+				"inherits": "2.0.3",
+				"readable-stream": "2.3.6",
+				"stream-shift": "1.0.0"
 			}
 		},
 		"ecc-jsbn": {
@@ -1711,7 +1711,7 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"jsbn": "~0.1.0"
+				"jsbn": "0.1.1"
 			}
 		},
 		"elegant-spinner": {
@@ -1725,7 +1725,7 @@
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
 			"integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
 			"requires": {
-				"env-variable": "0.0.x"
+				"env-variable": "0.0.5"
 			}
 		},
 		"end-of-stream": {
@@ -1734,7 +1734,7 @@
 			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
 			"dev": true,
 			"requires": {
-				"once": "^1.4.0"
+				"once": "1.4.0"
 			}
 		},
 		"env-variable": {
@@ -1748,7 +1748,7 @@
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -1757,11 +1757,11 @@
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.2.0",
+				"function-bind": "1.1.1",
+				"has": "1.0.3",
+				"is-callable": "1.1.4",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -1770,9 +1770,9 @@
 			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.4",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.2"
+				"is-callable": "1.1.4",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.2"
 			}
 		},
 		"escape-string-regexp": {
@@ -1787,11 +1787,11 @@
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -1826,13 +1826,13 @@
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
 				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
 			}
 		},
 		"exec-sh": {
@@ -1841,7 +1841,7 @@
 			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
 			"dev": true,
 			"requires": {
-				"merge": "^1.2.0"
+				"merge": "1.2.1"
 			}
 		},
 		"execa": {
@@ -1850,13 +1850,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"exit": {
@@ -1877,7 +1877,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"is-posix-bracket": "0.1.1"
 			}
 		},
 		"expand-range": {
@@ -1886,7 +1886,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.4"
 			}
 		},
 		"expect": {
@@ -1895,12 +1895,12 @@
 			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"jest-diff": "^23.6.0",
-				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0"
+				"ansi-styles": "3.2.1",
+				"jest-diff": "23.6.0",
+				"jest-get-type": "22.4.3",
+				"jest-matcher-utils": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-regex-util": "23.3.0"
 			}
 		},
 		"extend": {
@@ -1915,7 +1915,7 @@
 			"integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^1.1.0"
+				"kind-of": "1.1.0"
 			}
 		},
 		"extglob": {
@@ -1924,7 +1924,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -1970,7 +1970,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.0.0"
 			}
 		},
 		"fd-slicer": {
@@ -1979,7 +1979,7 @@
 			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"dev": true,
 			"requires": {
-				"pend": "~1.2.0"
+				"pend": "1.2.0"
 			}
 		},
 		"fecha": {
@@ -1993,8 +1993,8 @@
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
+				"escape-string-regexp": "1.0.5",
+				"object-assign": "4.1.1"
 			}
 		},
 		"filename-regex": {
@@ -2009,8 +2009,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
+				"glob": "7.1.2",
+				"minimatch": "3.0.4"
 			}
 		},
 		"fill-range": {
@@ -2019,11 +2019,11 @@
 			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "3.0.0",
+				"repeat-element": "1.1.2",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"find-parent-dir": {
@@ -2038,7 +2038,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"first-chunk-stream": {
@@ -2058,7 +2058,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"forever-agent": {
@@ -2073,9 +2073,9 @@
 			"integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
+				"asynckit": "0.4.0",
 				"combined-stream": "1.0.6",
-				"mime-types": "^2.1.12"
+				"mime-types": "2.1.18"
 			}
 		},
 		"fragment-cache": {
@@ -2083,7 +2083,7 @@
 			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"from": {
@@ -2104,8 +2104,8 @@
 			"integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "2.10.0",
+				"node-pre-gyp": "0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -2131,8 +2131,8 @@
 					"integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
@@ -2145,7 +2145,7 @@
 					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -2209,7 +2209,7 @@
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -2224,14 +2224,14 @@
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -2240,12 +2240,12 @@
 					"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -2260,7 +2260,7 @@
 					"integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -2269,7 +2269,7 @@
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -2278,8 +2278,8 @@
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -2298,7 +2298,7 @@
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -2312,7 +2312,7 @@
 					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -2325,8 +2325,8 @@
 					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -2335,7 +2335,7 @@
 					"integrity": "sha512-4T6Ur/GctZ27nHfpt9THOdRZNgyJ9FZchYO1ceg5S8Q3DNLCKYy44nCZzgCJgcvx2UM8czmqak5BCxJMrq37lA==",
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
@@ -2358,9 +2358,9 @@
 					"integrity": "sha512-eFagy6c+TYayorXw/qtAdSvaUpEbBsDwDyxYFgLZ0lTojfH7K+OdBqAF7TAFwDokJaGpubpSGG0wO3iC0XPi8w==",
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -2369,16 +2369,16 @@
 					"integrity": "sha512-G7kEonQLRbcA/mOoFoxvlMrw6Q6dPf92+t/l0DFSMuSlDoWaI9JWIyPwK0jyE1bph//CUEL65/Fz1m2vJbmjQQ==",
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.7",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -2387,8 +2387,8 @@
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -2403,8 +2403,8 @@
 					"integrity": "sha512-AQC0Dyhzn4EiYEfIUjCdMl0JJ61I2ER9ukf/sLxJUcZHfo+VyEfz2rMJgLZSS1v30OxPQe1cN0LZA1xbcaVfWA==",
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -2413,10 +2413,10 @@
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2435,7 +2435,7 @@
 					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2456,8 +2456,8 @@
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -2478,10 +2478,10 @@
 					"integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2498,13 +2498,13 @@
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -2513,7 +2513,7 @@
 					"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -2556,9 +2556,9 @@
 					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -2567,7 +2567,7 @@
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -2575,7 +2575,7 @@
 					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -2590,13 +2590,13 @@
 					"integrity": "sha512-O+v1r9yN4tOsvl90p5HAP4AEqbYhx4036AGMm075fH9F8Qwi3oJ+v4u50FkT/KkvywNGtwkk0zRI+8eYm1X/xg==",
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -2611,7 +2611,7 @@
 					"integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -2632,10 +2632,10 @@
 			"integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"inherits": "~2.0.0",
-				"mkdirp": ">=0.5 0",
-				"rimraf": "2"
+				"graceful-fs": "4.1.11",
+				"inherits": "2.0.3",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2"
 			}
 		},
 		"function-bind": {
@@ -2678,7 +2678,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"glob": {
@@ -2687,12 +2687,12 @@
 			"integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -2701,8 +2701,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			},
 			"dependencies": {
 				"glob-parent": {
@@ -2711,7 +2711,7 @@
 					"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 					"dev": true,
 					"requires": {
-						"is-glob": "^2.0.0"
+						"is-glob": "2.0.1"
 					}
 				},
 				"is-extglob": {
@@ -2726,7 +2726,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				}
 			}
@@ -2736,8 +2736,8 @@
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
 			"integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
 			"requires": {
-				"is-glob": "^3.1.0",
-				"path-dirname": "^1.0.0"
+				"is-glob": "3.1.0",
+				"path-dirname": "1.0.2"
 			}
 		},
 		"glob-stream": {
@@ -2746,14 +2746,14 @@
 			"integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
 			"dev": true,
 			"requires": {
-				"extend": "^3.0.0",
-				"glob": "^5.0.3",
-				"glob-parent": "^3.0.0",
-				"micromatch": "^2.3.7",
-				"ordered-read-streams": "^0.3.0",
-				"through2": "^0.6.0",
-				"to-absolute-glob": "^0.1.1",
-				"unique-stream": "^2.0.2"
+				"extend": "3.0.1",
+				"glob": "5.0.15",
+				"glob-parent": "3.1.0",
+				"micromatch": "2.3.11",
+				"ordered-read-streams": "0.3.0",
+				"through2": "0.6.5",
+				"to-absolute-glob": "0.1.1",
+				"unique-stream": "2.2.1"
 			},
 			"dependencies": {
 				"glob": {
@@ -2762,11 +2762,11 @@
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 					"dev": true,
 					"requires": {
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "2 || 3",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -2781,10 +2781,10 @@
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
 						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
+						"string_decoder": "0.10.31"
 					}
 				},
 				"string_decoder": {
@@ -2799,8 +2799,8 @@
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
 					"dev": true,
 					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
 					}
 				}
 			}
@@ -2834,9 +2834,9 @@
 			"integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
 			"dev": true,
 			"requires": {
-				"deep-assign": "^1.0.0",
-				"stat-mode": "^0.2.0",
-				"through2": "^2.0.0"
+				"deep-assign": "1.0.0",
+				"stat-mode": "0.2.2",
+				"through2": "2.0.3"
 			}
 		},
 		"gulp-filter": {
@@ -2845,9 +2845,9 @@
 			"integrity": "sha1-oF4Rr/sHz33PQafeHLe2OsN4PnM=",
 			"dev": true,
 			"requires": {
-				"multimatch": "^2.0.0",
-				"plugin-error": "^0.1.2",
-				"streamfilter": "^1.0.5"
+				"multimatch": "2.1.0",
+				"plugin-error": "0.1.2",
+				"streamfilter": "1.0.7"
 			}
 		},
 		"gulp-gunzip": {
@@ -2856,8 +2856,8 @@
 			"integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
 			"dev": true,
 			"requires": {
-				"through2": "~0.6.5",
-				"vinyl": "~0.4.6"
+				"through2": "0.6.5",
+				"vinyl": "0.4.6"
 			},
 			"dependencies": {
 				"isarray": {
@@ -2872,10 +2872,10 @@
 					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
 					"dev": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.1",
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
 						"isarray": "0.0.1",
-						"string_decoder": "~0.10.x"
+						"string_decoder": "0.10.31"
 					}
 				},
 				"string_decoder": {
@@ -2890,8 +2890,8 @@
 					"integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
 					"dev": true,
 					"requires": {
-						"readable-stream": ">=1.0.33-1 <1.1.0-0",
-						"xtend": ">=4.0.0 <4.1.0-0"
+						"readable-stream": "1.0.34",
+						"xtend": "4.0.1"
 					}
 				}
 			}
@@ -2902,11 +2902,11 @@
 			"integrity": "sha512-/9vtSk9eI9DEWCqzGieglPqmx0WUQ9pwPHyHFpKmfxqdgqGJC2l0vFMdYs54hLdDsMDEZFLDL2J4ikjc4hQ5HQ==",
 			"dev": true,
 			"requires": {
-				"event-stream": "^3.3.4",
-				"node.extend": "^1.1.2",
-				"request": "^2.79.0",
-				"through2": "^2.0.3",
-				"vinyl": "^2.0.1"
+				"event-stream": "3.3.4",
+				"node.extend": "1.1.6",
+				"request": "2.87.0",
+				"through2": "2.0.3",
+				"vinyl": "2.2.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -2927,12 +2927,12 @@
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
 					"dev": true,
 					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
+						"clone": "2.1.2",
+						"clone-buffer": "1.0.0",
+						"clone-stats": "1.0.0",
+						"cloneable-readable": "1.1.2",
+						"remove-trailing-separator": "1.1.0",
+						"replace-ext": "1.0.0"
 					}
 				}
 			}
@@ -2943,11 +2943,11 @@
 			"integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
 			"dev": true,
 			"requires": {
-				"convert-source-map": "^1.1.1",
-				"graceful-fs": "^4.1.2",
-				"strip-bom": "^2.0.0",
-				"through2": "^2.0.0",
-				"vinyl": "^1.0.0"
+				"convert-source-map": "1.5.1",
+				"graceful-fs": "4.1.11",
+				"strip-bom": "2.0.0",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -2968,8 +2968,8 @@
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 					"dev": true,
 					"requires": {
-						"clone": "^1.0.0",
-						"clone-stats": "^0.0.1",
+						"clone": "1.0.4",
+						"clone-stats": "0.0.1",
 						"replace-ext": "0.0.1"
 					}
 				}
@@ -2981,10 +2981,10 @@
 			"integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
 			"dev": true,
 			"requires": {
-				"event-stream": "^3.3.1",
-				"mkdirp": "^0.5.1",
-				"queue": "^3.1.0",
-				"vinyl-fs": "^2.4.3"
+				"event-stream": "3.3.4",
+				"mkdirp": "0.5.1",
+				"queue": "3.1.0",
+				"vinyl-fs": "2.4.4"
 			}
 		},
 		"gulp-untar": {
@@ -2993,11 +2993,11 @@
 			"integrity": "sha512-0QfbCH2a1k2qkTLWPqTX+QO4qNsHn3kC546YhAP3/n0h+nvtyGITDuDrYBMDZeW4WnFijmkOvBWa5HshTic1tw==",
 			"dev": true,
 			"requires": {
-				"event-stream": "~3.3.4",
-				"streamifier": "~0.1.1",
-				"tar": "^2.2.1",
-				"through2": "~2.0.3",
-				"vinyl": "^1.2.0"
+				"event-stream": "3.3.4",
+				"streamifier": "0.1.1",
+				"tar": "2.2.1",
+				"through2": "2.0.3",
+				"vinyl": "1.2.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -3018,8 +3018,8 @@
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 					"dev": true,
 					"requires": {
-						"clone": "^1.0.0",
-						"clone-stats": "^0.0.1",
+						"clone": "1.0.4",
+						"clone-stats": "0.0.1",
 						"replace-ext": "0.0.1"
 					}
 				}
@@ -3031,13 +3031,13 @@
 			"integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
 			"dev": true,
 			"requires": {
-				"event-stream": "^3.3.1",
-				"queue": "^4.2.1",
-				"through2": "^2.0.3",
-				"vinyl": "^2.0.2",
-				"vinyl-fs": "^2.0.0",
-				"yauzl": "^2.2.1",
-				"yazl": "^2.2.1"
+				"event-stream": "3.3.4",
+				"queue": "4.5.0",
+				"through2": "2.0.3",
+				"vinyl": "2.2.0",
+				"vinyl-fs": "2.4.4",
+				"yauzl": "2.10.0",
+				"yazl": "2.4.3"
 			},
 			"dependencies": {
 				"clone": {
@@ -3058,7 +3058,7 @@
 					"integrity": "sha512-DwxpAnqJuoQa+wyDgQuwkSshkhlqIlWEvwvdAY27fDPunZ2cVJzXU4JyjY+5l7zs7oGLaYAQm4MbLOVFAHFBzA==",
 					"dev": true,
 					"requires": {
-						"inherits": "~2.0.0"
+						"inherits": "2.0.3"
 					}
 				},
 				"vinyl": {
@@ -3067,12 +3067,12 @@
 					"integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
 					"dev": true,
 					"requires": {
-						"clone": "^2.1.1",
-						"clone-buffer": "^1.0.0",
-						"clone-stats": "^1.0.0",
-						"cloneable-readable": "^1.0.0",
-						"remove-trailing-separator": "^1.0.1",
-						"replace-ext": "^1.0.0"
+						"clone": "2.1.2",
+						"clone-buffer": "1.0.0",
+						"clone-stats": "1.0.0",
+						"cloneable-readable": "1.1.2",
+						"remove-trailing-separator": "1.1.0",
+						"replace-ext": "1.0.0"
 					}
 				}
 			}
@@ -3083,10 +3083,10 @@
 			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.5.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
+				"async": "2.6.1",
+				"optimist": "0.6.1",
+				"source-map": "0.6.1",
+				"uglify-js": "3.4.9"
 			}
 		},
 		"har-schema": {
@@ -3101,8 +3101,8 @@
 			"integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.1.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -3111,7 +3111,7 @@
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.1.1"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -3120,7 +3120,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-flag": {
@@ -3140,9 +3140,9 @@
 			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -3157,8 +3157,8 @@
 			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -3166,7 +3166,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3174,7 +3174,7 @@
 							"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -3184,7 +3184,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3201,8 +3201,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -3217,7 +3217,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.5"
 			}
 		},
 		"http-signature": {
@@ -3226,9 +3226,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.14.1"
 			}
 		},
 		"iconv-lite": {
@@ -3237,7 +3237,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"import-local": {
@@ -3246,8 +3246,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -3268,8 +3268,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -3283,7 +3283,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.4.0"
 			}
 		},
 		"invert-kv": {
@@ -3302,7 +3302,7 @@
 			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3310,7 +3310,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3327,7 +3327,7 @@
 			"integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
 			"optional": true,
 			"requires": {
-				"binary-extensions": "^1.0.0"
+				"binary-extensions": "1.11.0"
 			}
 		},
 		"is-buffer": {
@@ -3341,7 +3341,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -3356,7 +3356,7 @@
 			"integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.5.0"
+				"ci-info": "1.6.0"
 			}
 		},
 		"is-data-descriptor": {
@@ -3364,7 +3364,7 @@
 			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3372,7 +3372,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3388,9 +3388,9 @@
 			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3418,7 +3418,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -3437,7 +3437,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -3445,7 +3445,7 @@
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-generator-fn": {
@@ -3459,7 +3459,7 @@
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
 			"integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
 			"requires": {
-				"is-extglob": "^2.1.0"
+				"is-extglob": "2.1.1"
 			}
 		},
 		"is-number": {
@@ -3468,7 +3468,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -3477,7 +3477,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -3494,7 +3494,7 @@
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "^1.1.0"
+				"symbol-observable": "1.2.0"
 			}
 		},
 		"is-odd": {
@@ -3502,7 +3502,7 @@
 			"resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
 			"integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
 			"requires": {
-				"is-number": "^4.0.0"
+				"is-number": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -3517,7 +3517,7 @@
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -3551,7 +3551,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.3"
 			}
 		},
 		"is-regexp": {
@@ -3571,7 +3571,7 @@
 			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
 			"dev": true,
 			"requires": {
-				"has-symbols": "^1.0.0"
+				"has-symbols": "1.0.0"
 			}
 		},
 		"is-typedarray": {
@@ -3629,17 +3629,17 @@
 			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.1",
-				"istanbul-lib-hook": "^1.2.2",
-				"istanbul-lib-instrument": "^1.10.2",
-				"istanbul-lib-report": "^1.1.5",
-				"istanbul-lib-source-maps": "^1.2.6",
-				"istanbul-reports": "^1.5.1",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
+				"async": "2.6.1",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.2.1",
+				"istanbul-lib-hook": "1.2.2",
+				"istanbul-lib-instrument": "1.10.2",
+				"istanbul-lib-report": "1.1.5",
+				"istanbul-lib-source-maps": "1.2.6",
+				"istanbul-reports": "1.5.1",
+				"js-yaml": "3.12.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -3654,7 +3654,7 @@
 			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
 			"dev": true,
 			"requires": {
-				"append-transform": "^0.4.0"
+				"append-transform": "0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -3663,13 +3663,13 @@
 			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"semver": "^5.3.0"
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.2.1",
+				"semver": "5.5.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -3678,10 +3678,10 @@
 			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "1.2.1",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.6",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -3696,7 +3696,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -3707,11 +3707,11 @@
 			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "3.1.0",
+				"istanbul-lib-coverage": "1.2.1",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3728,7 +3728,7 @@
 			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "4.0.12"
 			}
 		},
 		"jest": {
@@ -3737,8 +3737,8 @@
 			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
 			"dev": true,
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^23.6.0"
+				"import-local": "1.0.0",
+				"jest-cli": "23.6.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -3753,9 +3753,9 @@
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -3770,42 +3770,42 @@
 					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.3.1",
-						"istanbul-lib-coverage": "^1.2.0",
-						"istanbul-lib-instrument": "^1.10.1",
-						"istanbul-lib-source-maps": "^1.2.4",
-						"jest-changed-files": "^23.4.2",
-						"jest-config": "^23.6.0",
-						"jest-environment-jsdom": "^23.4.0",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-regex-util": "^23.3.0",
-						"jest-resolve-dependencies": "^23.6.0",
-						"jest-runner": "^23.6.0",
-						"jest-runtime": "^23.6.0",
-						"jest-snapshot": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"jest-validate": "^23.6.0",
-						"jest-watcher": "^23.4.0",
-						"jest-worker": "^23.2.0",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"prompts": "^0.1.9",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^11.0.0"
+						"ansi-escapes": "3.1.0",
+						"chalk": "2.4.1",
+						"exit": "0.1.2",
+						"glob": "7.1.2",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.2.1",
+						"istanbul-api": "1.3.7",
+						"istanbul-lib-coverage": "1.2.1",
+						"istanbul-lib-instrument": "1.10.2",
+						"istanbul-lib-source-maps": "1.2.6",
+						"jest-changed-files": "23.4.2",
+						"jest-config": "23.6.0",
+						"jest-environment-jsdom": "23.4.0",
+						"jest-get-type": "22.4.3",
+						"jest-haste-map": "23.6.0",
+						"jest-message-util": "23.4.0",
+						"jest-regex-util": "23.3.0",
+						"jest-resolve-dependencies": "23.6.0",
+						"jest-runner": "23.6.0",
+						"jest-runtime": "23.6.0",
+						"jest-snapshot": "23.6.0",
+						"jest-util": "23.4.0",
+						"jest-validate": "23.6.0",
+						"jest-watcher": "23.4.0",
+						"jest-worker": "23.2.0",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.3.0",
+						"prompts": "0.1.14",
+						"realpath-native": "1.0.2",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.1",
+						"yargs": "11.1.0"
 					}
 				},
 				"os-locale": {
@@ -3814,9 +3814,9 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
 					}
 				},
 				"string-width": {
@@ -3825,8 +3825,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -3835,7 +3835,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"yargs": {
@@ -3844,18 +3844,18 @@
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.3",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					}
 				}
 			}
@@ -3866,7 +3866,7 @@
 			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
 			"dev": true,
 			"requires": {
-				"throat": "^4.0.0"
+				"throat": "4.1.0"
 			}
 		},
 		"jest-config": {
@@ -3875,20 +3875,20 @@
 			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^23.6.0",
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^23.4.0",
-				"jest-environment-node": "^23.4.0",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
-				"pretty-format": "^23.6.0"
+				"babel-core": "6.26.3",
+				"babel-jest": "23.6.0",
+				"chalk": "2.4.1",
+				"glob": "7.1.2",
+				"jest-environment-jsdom": "23.4.0",
+				"jest-environment-node": "23.4.0",
+				"jest-get-type": "22.4.3",
+				"jest-jasmine2": "23.6.0",
+				"jest-regex-util": "23.3.0",
+				"jest-resolve": "23.6.0",
+				"jest-util": "23.4.0",
+				"jest-validate": "23.6.0",
+				"micromatch": "2.3.11",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-diff": {
@@ -3897,10 +3897,10 @@
 			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.4.1",
+				"diff": "3.3.1",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-docblock": {
@@ -3909,7 +3909,7 @@
 			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			}
 		},
 		"jest-each": {
@@ -3918,8 +3918,8 @@
 			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.4.1",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -3928,9 +3928,9 @@
 			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0",
-				"jsdom": "^11.5.1"
+				"jest-mock": "23.2.0",
+				"jest-util": "23.4.0",
+				"jsdom": "11.12.0"
 			}
 		},
 		"jest-environment-node": {
@@ -3939,8 +3939,8 @@
 			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0"
+				"jest-mock": "23.2.0",
+				"jest-util": "23.4.0"
 			}
 		},
 		"jest-get-type": {
@@ -3955,14 +3955,14 @@
 			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"invariant": "^2.2.4",
-				"jest-docblock": "^23.2.0",
-				"jest-serializer": "^23.0.1",
-				"jest-worker": "^23.2.0",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"invariant": "2.2.4",
+				"jest-docblock": "23.2.0",
+				"jest-serializer": "23.0.1",
+				"jest-worker": "23.2.0",
+				"micromatch": "2.3.11",
+				"sane": "2.5.2"
 			}
 		},
 		"jest-jasmine2": {
@@ -3971,18 +3971,18 @@
 			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
 			"dev": true,
 			"requires": {
-				"babel-traverse": "^6.0.0",
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^23.6.0",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^23.6.0",
-				"jest-each": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"pretty-format": "^23.6.0"
+				"babel-traverse": "6.26.0",
+				"chalk": "2.4.1",
+				"co": "4.6.0",
+				"expect": "23.6.0",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "23.6.0",
+				"jest-each": "23.6.0",
+				"jest-matcher-utils": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-snapshot": "23.6.0",
+				"jest-util": "23.4.0",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-leak-detector": {
@@ -3991,7 +3991,7 @@
 			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^23.6.0"
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -4000,9 +4000,9 @@
 			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.4.1",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-message-util": {
@@ -4011,11 +4011,11 @@
 			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
-				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.0.0",
+				"chalk": "2.4.1",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
 			}
 		},
 		"jest-mock": {
@@ -4036,9 +4036,9 @@
 			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "^1.11.3",
-				"chalk": "^2.0.1",
-				"realpath-native": "^1.0.0"
+				"browser-resolve": "1.11.3",
+				"chalk": "2.4.1",
+				"realpath-native": "1.0.2"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -4047,8 +4047,8 @@
 			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^23.3.0",
-				"jest-snapshot": "^23.6.0"
+				"jest-regex-util": "23.3.0",
+				"jest-snapshot": "23.6.0"
 			}
 		},
 		"jest-runner": {
@@ -4057,19 +4057,19 @@
 			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
 			"dev": true,
 			"requires": {
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-docblock": "^23.2.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-leak-detector": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-runtime": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-worker": "^23.2.0",
-				"source-map-support": "^0.5.6",
-				"throat": "^4.0.0"
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "23.6.0",
+				"jest-docblock": "23.2.0",
+				"jest-haste-map": "23.6.0",
+				"jest-jasmine2": "23.6.0",
+				"jest-leak-detector": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-runtime": "23.6.0",
+				"jest-util": "23.4.0",
+				"jest-worker": "23.2.0",
+				"source-map-support": "0.5.6",
+				"throat": "4.1.0"
 			}
 		},
 		"jest-runtime": {
@@ -4078,27 +4078,27 @@
 			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-plugin-istanbul": "^4.1.6",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"exit": "^0.1.2",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
+				"babel-core": "6.26.3",
+				"babel-plugin-istanbul": "4.1.6",
+				"chalk": "2.4.1",
+				"convert-source-map": "1.5.1",
+				"exit": "0.1.2",
+				"fast-json-stable-stringify": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-config": "23.6.0",
+				"jest-haste-map": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-regex-util": "23.3.0",
+				"jest-resolve": "23.6.0",
+				"jest-snapshot": "23.6.0",
+				"jest-util": "23.4.0",
+				"jest-validate": "23.6.0",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.2",
+				"slash": "1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^11.0.0"
+				"write-file-atomic": "2.3.0",
+				"yargs": "11.1.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4113,9 +4113,9 @@
 					"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1",
-						"strip-ansi": "^4.0.0",
-						"wrap-ansi": "^2.0.0"
+						"string-width": "2.1.1",
+						"strip-ansi": "4.0.0",
+						"wrap-ansi": "2.1.0"
 					}
 				},
 				"is-fullwidth-code-point": {
@@ -4130,9 +4130,9 @@
 					"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 					"dev": true,
 					"requires": {
-						"execa": "^0.7.0",
-						"lcid": "^1.0.0",
-						"mem": "^1.1.0"
+						"execa": "0.7.0",
+						"lcid": "1.0.0",
+						"mem": "1.1.0"
 					}
 				},
 				"string-width": {
@@ -4141,8 +4141,8 @@
 					"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
+						"is-fullwidth-code-point": "2.0.0",
+						"strip-ansi": "4.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4151,7 +4151,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				},
 				"strip-bom": {
@@ -4166,18 +4166,18 @@
 					"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 					"dev": true,
 					"requires": {
-						"cliui": "^4.0.0",
-						"decamelize": "^1.1.1",
-						"find-up": "^2.1.0",
-						"get-caller-file": "^1.0.1",
-						"os-locale": "^2.0.0",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^1.0.1",
-						"set-blocking": "^2.0.0",
-						"string-width": "^2.0.0",
-						"which-module": "^2.0.0",
-						"y18n": "^3.2.1",
-						"yargs-parser": "^9.0.2"
+						"cliui": "4.1.0",
+						"decamelize": "1.2.0",
+						"find-up": "2.1.0",
+						"get-caller-file": "1.0.3",
+						"os-locale": "2.1.0",
+						"require-directory": "2.1.1",
+						"require-main-filename": "1.0.1",
+						"set-blocking": "2.0.0",
+						"string-width": "2.1.1",
+						"which-module": "2.0.0",
+						"y18n": "3.2.1",
+						"yargs-parser": "9.0.2"
 					}
 				}
 			}
@@ -4194,16 +4194,16 @@
 			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
 			"dev": true,
 			"requires": {
-				"babel-types": "^6.0.0",
-				"chalk": "^2.0.1",
-				"jest-diff": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-resolve": "^23.6.0",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^23.6.0",
-				"semver": "^5.5.0"
+				"babel-types": "6.26.0",
+				"chalk": "2.4.1",
+				"jest-diff": "23.6.0",
+				"jest-matcher-utils": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-resolve": "23.6.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "23.6.0",
+				"semver": "5.5.0"
 			}
 		},
 		"jest-util": {
@@ -4212,14 +4212,14 @@
 			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^23.4.0",
-				"mkdirp": "^0.5.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.6.0"
+				"callsites": "2.0.0",
+				"chalk": "2.4.1",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.2.1",
+				"jest-message-util": "23.4.0",
+				"mkdirp": "0.5.1",
+				"slash": "1.0.0",
+				"source-map": "0.6.1"
 			}
 		},
 		"jest-validate": {
@@ -4228,10 +4228,10 @@
 			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.4.1",
+				"jest-get-type": "22.4.3",
+				"leven": "2.1.0",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-watcher": {
@@ -4240,9 +4240,9 @@
 			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"string-length": "^2.0.0"
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.4.1",
+				"string-length": "2.0.0"
 			}
 		},
 		"jest-worker": {
@@ -4251,7 +4251,7 @@
 			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1"
+				"merge-stream": "1.0.1"
 			}
 		},
 		"js-tokens": {
@@ -4266,8 +4266,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.1"
 			}
 		},
 		"jsbn": {
@@ -4283,32 +4283,32 @@
 			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^5.5.3",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": "^1.0.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.9.1",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.3.0",
-				"nwsapi": "^2.0.7",
+				"abab": "2.0.0",
+				"acorn": "5.7.3",
+				"acorn-globals": "4.3.0",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.4",
+				"cssstyle": "1.1.1",
+				"data-urls": "1.1.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.11.0",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwsapi": "2.0.9",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.87.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.4",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^5.2.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.87.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.3.4",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.5",
+				"whatwg-mimetype": "2.2.0",
+				"whatwg-url": "6.5.0",
+				"ws": "5.2.2",
+				"xml-name-validator": "3.0.0"
 			}
 		},
 		"jsesc": {
@@ -4341,7 +4341,7 @@
 			"integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
 			"dev": true,
 			"requires": {
-				"jsonify": "~0.0.0"
+				"jsonify": "0.0.0"
 			}
 		},
 		"json-stringify-safe": {
@@ -4390,7 +4390,7 @@
 			"resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
 			"integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
 			"requires": {
-				"colornames": "^1.1.1"
+				"colornames": "1.1.1"
 			}
 		},
 		"lazystream": {
@@ -4399,7 +4399,7 @@
 			"integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.5"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"lcid": {
@@ -4407,7 +4407,7 @@
 			"resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"left-pad": {
@@ -4428,8 +4428,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"lint-staged": {
@@ -4438,28 +4438,28 @@
 			"integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.1",
-				"commander": "^2.14.1",
-				"cosmiconfig": "^5.0.2",
-				"debug": "^3.1.0",
-				"dedent": "^0.7.0",
-				"execa": "^0.9.0",
-				"find-parent-dir": "^0.3.0",
-				"is-glob": "^4.0.0",
-				"is-windows": "^1.0.2",
-				"jest-validate": "^23.5.0",
-				"listr": "^0.14.1",
-				"lodash": "^4.17.5",
-				"log-symbols": "^2.2.0",
-				"micromatch": "^3.1.8",
-				"npm-which": "^3.0.1",
-				"p-map": "^1.1.1",
-				"path-is-inside": "^1.0.2",
-				"pify": "^3.0.0",
-				"please-upgrade-node": "^3.0.2",
+				"chalk": "2.4.1",
+				"commander": "2.17.1",
+				"cosmiconfig": "5.0.6",
+				"debug": "3.1.0",
+				"dedent": "0.7.0",
+				"execa": "0.9.0",
+				"find-parent-dir": "0.3.0",
+				"is-glob": "4.0.0",
+				"is-windows": "1.0.2",
+				"jest-validate": "23.6.0",
+				"listr": "0.14.2",
+				"lodash": "4.17.11",
+				"log-symbols": "2.2.0",
+				"micromatch": "3.1.10",
+				"npm-which": "3.0.1",
+				"p-map": "1.2.0",
+				"path-is-inside": "1.0.2",
+				"pify": "3.0.0",
+				"please-upgrade-node": "3.1.1",
 				"staged-git-files": "1.1.1",
-				"string-argv": "^0.0.2",
-				"stringify-object": "^3.2.2"
+				"string-argv": "0.0.2",
+				"stringify-object": "3.3.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -4480,16 +4480,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4498,7 +4498,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -4509,13 +4509,13 @@
 					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"expand-brackets": {
@@ -4524,13 +4524,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -4548,7 +4548,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -4557,7 +4557,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -4566,7 +4566,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4575,7 +4575,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -4586,7 +4586,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -4595,7 +4595,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -4606,9 +4606,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -4625,8 +4625,8 @@
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"dev": true,
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -4635,7 +4635,7 @@
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"dev": true,
 							"requires": {
-								"is-plain-object": "^2.0.4"
+								"is-plain-object": "2.0.4"
 							}
 						}
 					}
@@ -4646,14 +4646,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -4662,7 +4662,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -4671,7 +4671,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -4682,10 +4682,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -4694,7 +4694,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -4705,7 +4705,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -4714,7 +4714,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -4723,9 +4723,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-glob": {
@@ -4734,7 +4734,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"is-number": {
@@ -4743,7 +4743,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -4752,7 +4752,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4775,19 +4775,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"pify": {
@@ -4804,15 +4804,15 @@
 			"integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
 			"dev": true,
 			"requires": {
-				"@samverschueren/stream-to-observable": "^0.3.0",
-				"is-observable": "^1.1.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.4.0",
-				"listr-verbose-renderer": "^0.4.0",
-				"p-map": "^1.1.1",
-				"rxjs": "^6.1.0"
+				"@samverschueren/stream-to-observable": "0.3.0",
+				"is-observable": "1.1.0",
+				"is-promise": "2.1.0",
+				"is-stream": "1.1.0",
+				"listr-silent-renderer": "1.1.1",
+				"listr-update-renderer": "0.4.0",
+				"listr-verbose-renderer": "0.4.1",
+				"p-map": "1.2.0",
+				"rxjs": "6.3.3"
 			}
 		},
 		"listr-silent-renderer": {
@@ -4827,14 +4827,14 @@
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"strip-ansi": "^3.0.1"
+				"chalk": "1.1.3",
+				"cli-truncate": "0.2.1",
+				"elegant-spinner": "1.0.1",
+				"figures": "1.7.0",
+				"indent-string": "3.2.0",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4849,11 +4849,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"log-symbols": {
@@ -4862,7 +4862,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.0.0"
+						"chalk": "1.1.3"
 					}
 				},
 				"supports-color": {
@@ -4879,10 +4879,10 @@
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-cursor": "^1.0.2",
-				"date-fns": "^1.27.2",
-				"figures": "^1.7.0"
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"date-fns": "1.29.0",
+				"figures": "1.7.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4897,11 +4897,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"supports-color": {
@@ -4918,11 +4918,11 @@
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^2.2.0",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0",
-				"strip-bom": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "2.2.0",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1",
+				"strip-bom": "2.0.0"
 			}
 		},
 		"locate-path": {
@@ -4931,8 +4931,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -4964,7 +4964,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "2.4.1"
 			}
 		},
 		"log-update": {
@@ -4973,8 +4973,8 @@
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^1.0.0",
-				"cli-cursor": "^1.0.2"
+				"ansi-escapes": "1.4.0",
+				"cli-cursor": "1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -4990,11 +4990,11 @@
 			"resolved": "https://registry.npmjs.org/logform/-/logform-1.10.0.tgz",
 			"integrity": "sha512-em5ojIhU18fIMOw/333mD+ZLE2fis0EzXl1ZwHx4iQzmpQi6odNiY/t+ITNr33JZhT9/KEaH+UPIipr6a9EjWg==",
 			"requires": {
-				"colors": "^1.2.1",
-				"fast-safe-stringify": "^2.0.4",
-				"fecha": "^2.3.3",
-				"ms": "^2.1.1",
-				"triple-beam": "^1.2.0"
+				"colors": "1.3.2",
+				"fast-safe-stringify": "2.0.6",
+				"fecha": "2.3.3",
+				"ms": "2.1.1",
+				"triple-beam": "1.3.0"
 			},
 			"dependencies": {
 				"ms": {
@@ -5010,7 +5010,7 @@
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
 			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -5019,8 +5019,8 @@
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"make-error": {
@@ -5035,7 +5035,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -5054,7 +5054,7 @@
 			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"math-random": {
@@ -5069,7 +5069,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"merge": {
@@ -5084,7 +5084,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"micromatch": {
@@ -5093,19 +5093,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -5114,7 +5114,7 @@
 					"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.0.1"
+						"arr-flatten": "1.1.0"
 					}
 				},
 				"is-extglob": {
@@ -5129,7 +5129,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				},
 				"kind-of": {
@@ -5138,7 +5138,7 @@
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5155,7 +5155,7 @@
 			"integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.33.0"
+				"mime-db": "1.33.0"
 			}
 		},
 		"mimic-fn": {
@@ -5169,7 +5169,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -5182,8 +5182,8 @@
 			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -5191,7 +5191,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -5234,7 +5234,7 @@
 					"integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^2.0.0"
+						"has-flag": "2.0.0"
 					}
 				}
 			}
@@ -5250,10 +5250,10 @@
 			"integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
 			"dev": true,
 			"requires": {
-				"array-differ": "^1.0.0",
-				"array-union": "^1.0.1",
-				"arrify": "^1.0.0",
-				"minimatch": "^3.0.0"
+				"array-differ": "1.0.0",
+				"array-union": "1.0.2",
+				"arrify": "1.0.1",
+				"minimatch": "3.0.4"
 			}
 		},
 		"nan": {
@@ -5267,18 +5267,18 @@
 			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
 			"integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-odd": "^2.0.0",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-odd": "2.0.0",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -5296,8 +5296,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					}
 				},
 				"is-extendable": {
@@ -5305,7 +5305,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				},
 				"kind-of": {
@@ -5326,15 +5326,15 @@
 			"resolved": "https://registry.npmjs.org/nock/-/nock-9.6.1.tgz",
 			"integrity": "sha512-EDgl/WgNQ0C1BZZlASOQkQdE6tAWXJi8QQlugqzN64JJkvZ7ILijZuG24r4vCC7yOfnm6HKpne5AGExLGCeBWg==",
 			"requires": {
-				"chai": "^4.1.2",
-				"debug": "^3.1.0",
-				"deep-equal": "^1.0.0",
-				"json-stringify-safe": "^5.0.1",
-				"lodash": "^4.17.5",
-				"mkdirp": "^0.5.0",
-				"propagate": "^1.0.0",
-				"qs": "^6.5.1",
-				"semver": "^5.5.0"
+				"chai": "4.2.0",
+				"debug": "3.1.0",
+				"deep-equal": "1.0.1",
+				"json-stringify-safe": "5.0.1",
+				"lodash": "4.17.11",
+				"mkdirp": "0.5.1",
+				"propagate": "1.0.0",
+				"qs": "6.5.2",
+				"semver": "5.5.0"
 			}
 		},
 		"node-int64": {
@@ -5349,10 +5349,10 @@
 			"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"semver": "^5.5.0",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.1"
 			}
 		},
 		"node.extend": {
@@ -5361,7 +5361,7 @@
 			"integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
 			"dev": true,
 			"requires": {
-				"is": "^3.1.0"
+				"is": "3.2.1"
 			}
 		},
 		"normalize-package-data": {
@@ -5370,10 +5370,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.7.1",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.4"
 			}
 		},
 		"normalize-path": {
@@ -5381,7 +5381,7 @@
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
 			"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 			"requires": {
-				"remove-trailing-separator": "^1.0.1"
+				"remove-trailing-separator": "1.1.0"
 			}
 		},
 		"npm-path": {
@@ -5390,7 +5390,7 @@
 			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
 			"dev": true,
 			"requires": {
-				"which": "^1.2.10"
+				"which": "1.3.1"
 			}
 		},
 		"npm-run-path": {
@@ -5399,7 +5399,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"npm-which": {
@@ -5408,9 +5408,9 @@
 			"integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
 			"dev": true,
 			"requires": {
-				"commander": "^2.9.0",
-				"npm-path": "^2.0.2",
-				"which": "^1.2.10"
+				"commander": "2.17.1",
+				"npm-path": "2.0.4",
+				"which": "1.3.1"
 			}
 		},
 		"number-is-nan": {
@@ -5423,11 +5423,11 @@
 			"resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.1.3.tgz",
 			"integrity": "sha512-UtlKKAzg9vdtvURdNy9DjGhiB7qYf2R7Ez+hsucOQG5gYJexSggXSSZ+9IpSDyKOlWu/4rMVPH2oVoANOSqNKA==",
 			"requires": {
-				"a-sync-waterfall": "^1.0.0",
-				"asap": "^2.0.3",
-				"chokidar": "^2.0.0",
-				"postinstall-build": "^5.0.1",
-				"yargs": "^3.32.0"
+				"a-sync-waterfall": "1.0.0",
+				"asap": "2.0.6",
+				"chokidar": "2.0.4",
+				"postinstall-build": "5.0.1",
+				"yargs": "3.32.0"
 			}
 		},
 		"nwsapi": {
@@ -5453,9 +5453,9 @@
 			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5463,7 +5463,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"kind-of": {
@@ -5471,7 +5471,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -5487,7 +5487,7 @@
 			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -5503,8 +5503,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.3",
+				"es-abstract": "1.12.0"
 			}
 		},
 		"object.omit": {
@@ -5513,8 +5513,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -5522,7 +5522,7 @@
 			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -5538,7 +5538,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"one-time": {
@@ -5558,8 +5558,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
 			}
 		},
 		"optionator": {
@@ -5568,12 +5568,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -5590,8 +5590,8 @@
 			"integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
 			"dev": true,
 			"requires": {
-				"is-stream": "^1.0.1",
-				"readable-stream": "^2.0.1"
+				"is-stream": "1.1.0",
+				"readable-stream": "2.3.6"
 			}
 		},
 		"os-homedir": {
@@ -5605,7 +5605,7 @@
 			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
 			"integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
 			"requires": {
-				"lcid": "^1.0.0"
+				"lcid": "1.0.0"
 			}
 		},
 		"os-tmpdir": {
@@ -5626,7 +5626,7 @@
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -5635,7 +5635,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.3.0"
 			}
 		},
 		"p-map": {
@@ -5656,10 +5656,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			},
 			"dependencies": {
 				"is-extglob": {
@@ -5674,7 +5674,7 @@
 					"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^1.0.0"
+						"is-extglob": "1.0.0"
 					}
 				}
 			}
@@ -5685,7 +5685,7 @@
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.2.0"
+				"error-ex": "1.3.2"
 			}
 		},
 		"parse5": {
@@ -5739,9 +5739,9 @@
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"pify": "^2.0.0",
-				"pinkie-promise": "^2.0.0"
+				"graceful-fs": "4.1.11",
+				"pify": "2.3.0",
+				"pinkie-promise": "2.0.1"
 			}
 		},
 		"pathval": {
@@ -5755,7 +5755,7 @@
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
 			"dev": true,
 			"requires": {
-				"through": "~2.3"
+				"through": "2.3.8"
 			}
 		},
 		"pend": {
@@ -5788,7 +5788,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pkg-dir": {
@@ -5797,7 +5797,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"please-upgrade-node": {
@@ -5806,7 +5806,7 @@
 			"integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
 			"dev": true,
 			"requires": {
-				"semver-compare": "^1.0.0"
+				"semver-compare": "1.0.0"
 			}
 		},
 		"plugin-error": {
@@ -5815,11 +5815,11 @@
 			"integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
 			"dev": true,
 			"requires": {
-				"ansi-cyan": "^0.1.1",
-				"ansi-red": "^0.1.1",
-				"arr-diff": "^1.0.1",
-				"arr-union": "^2.0.1",
-				"extend-shallow": "^1.1.2"
+				"ansi-cyan": "0.1.1",
+				"ansi-red": "0.1.1",
+				"arr-diff": "1.1.0",
+				"arr-union": "2.1.0",
+				"extend-shallow": "1.1.4"
 			}
 		},
 		"pn": {
@@ -5862,8 +5862,8 @@
 			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -5891,8 +5891,8 @@
 			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
 			"dev": true,
 			"requires": {
-				"kleur": "^2.0.1",
-				"sisteransi": "^0.1.1"
+				"kleur": "2.0.2",
+				"sisteransi": "0.1.1"
 			}
 		},
 		"propagate": {
@@ -5934,7 +5934,7 @@
 			"integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
 			"dev": true,
 			"requires": {
-				"inherits": "~2.0.0"
+				"inherits": "2.0.3"
 			}
 		},
 		"randomatic": {
@@ -5943,9 +5943,9 @@
 			"integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
+				"is-number": "4.0.0",
+				"kind-of": "6.0.2",
+				"math-random": "1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -5968,9 +5968,9 @@
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^1.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^1.0.0"
+				"load-json-file": "1.1.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "1.1.0"
 			}
 		},
 		"read-pkg-up": {
@@ -5979,8 +5979,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -5989,8 +5989,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-exists": {
@@ -5999,7 +5999,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				}
 			}
@@ -6009,13 +6009,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"readdirp": {
@@ -6024,10 +6024,10 @@
 			"integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
 			"optional": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"minimatch": "^3.0.2",
-				"readable-stream": "^2.0.2",
-				"set-immediate-shim": "^1.0.1"
+				"graceful-fs": "4.1.11",
+				"minimatch": "3.0.4",
+				"readable-stream": "2.3.6",
+				"set-immediate-shim": "1.0.1"
 			}
 		},
 		"realpath-native": {
@@ -6036,7 +6036,7 @@
 			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"regenerator-runtime": {
@@ -6051,7 +6051,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -6059,8 +6059,8 @@
 			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -6068,8 +6068,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					}
 				},
 				"is-extendable": {
@@ -6077,7 +6077,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -6103,7 +6103,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"replace-ext": {
@@ -6118,26 +6118,26 @@
 			"integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.6.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.5",
-				"extend": "~3.0.1",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.1",
-				"har-validator": "~5.0.3",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.17",
-				"oauth-sign": "~0.8.2",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.1",
-				"safe-buffer": "^5.1.1",
-				"tough-cookie": "~2.3.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.1.0"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.7.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.6",
+				"extend": "3.0.1",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.2",
+				"har-validator": "5.0.3",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.18",
+				"oauth-sign": "0.8.2",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"tough-cookie": "2.3.4",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.2.1"
 			}
 		},
 		"request-promise-core": {
@@ -6146,7 +6146,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "4.17.11"
 			}
 		},
 		"request-promise-native": {
@@ -6156,8 +6156,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.3.4"
 			}
 		},
 		"require-directory": {
@@ -6190,7 +6190,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -6210,8 +6210,8 @@
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 			"dev": true,
 			"requires": {
-				"exit-hook": "^1.0.0",
-				"onetime": "^1.0.0"
+				"exit-hook": "1.1.1",
+				"onetime": "1.1.0"
 			}
 		},
 		"ret": {
@@ -6225,7 +6225,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.2"
 			}
 		},
 		"rsvp": {
@@ -6240,7 +6240,7 @@
 			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.9.0"
+				"tslib": "1.9.3"
 			}
 		},
 		"safe-buffer": {
@@ -6253,7 +6253,7 @@
 			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -6268,15 +6268,15 @@
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"capture-exit": "^1.2.0",
-				"exec-sh": "^0.2.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.3",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"anymatch": "2.0.0",
+				"capture-exit": "1.2.0",
+				"exec-sh": "0.2.2",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.4",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -6297,16 +6297,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.2",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -6315,7 +6315,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -6335,13 +6335,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -6350,7 +6350,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -6359,7 +6359,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -6368,7 +6368,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -6377,7 +6377,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -6388,7 +6388,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -6397,7 +6397,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -6408,9 +6408,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -6427,8 +6427,8 @@
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"dev": true,
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					},
 					"dependencies": {
 						"is-extendable": {
@@ -6437,7 +6437,7 @@
 							"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 							"dev": true,
 							"requires": {
-								"is-plain-object": "^2.0.4"
+								"is-plain-object": "2.0.4"
 							}
 						}
 					}
@@ -6448,14 +6448,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -6464,7 +6464,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -6473,7 +6473,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -6484,10 +6484,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -6496,7 +6496,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -6507,7 +6507,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -6516,7 +6516,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -6525,9 +6525,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -6536,7 +6536,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -6545,7 +6545,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -6568,19 +6568,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.9",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"minimist": {
@@ -6625,10 +6625,10 @@
 			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -6636,7 +6636,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -6647,7 +6647,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -6673,7 +6673,7 @@
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
 			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
 			"requires": {
-				"is-arrayish": "^0.3.1"
+				"is-arrayish": "0.3.2"
 			},
 			"dependencies": {
 				"is-arrayish": {
@@ -6706,14 +6706,14 @@
 			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -6729,7 +6729,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -6737,7 +6737,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"source-map": {
@@ -6752,9 +6752,9 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6762,7 +6762,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -6770,7 +6770,7 @@
 					"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -6778,7 +6778,7 @@
 					"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -6786,9 +6786,9 @@
 					"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -6808,7 +6808,7 @@
 			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -6816,7 +6816,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -6832,11 +6832,11 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.1",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -6845,8 +6845,8 @@
 			"integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
 			"dev": true,
 			"requires": {
-				"buffer-from": "^1.0.0",
-				"source-map": "^0.6.0"
+				"buffer-from": "1.0.0",
+				"source-map": "0.6.1"
 			}
 		},
 		"source-map-url": {
@@ -6860,8 +6860,8 @@
 			"integrity": "sha512-q9hedtzyXHr5S0A1vEPoK/7l8NpfkFYTq6iCY+Pno2ZbdZR6WexZFtqeVGkGxW3TEJMN914Z55EnAGMmenlIQQ==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.2"
 			}
 		},
 		"spdx-exceptions": {
@@ -6876,8 +6876,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.2.0",
+				"spdx-license-ids": "3.0.2"
 			}
 		},
 		"spdx-license-ids": {
@@ -6892,7 +6892,7 @@
 			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
 			"dev": true,
 			"requires": {
-				"through": "2"
+				"through": "2.3.8"
 			}
 		},
 		"split-string": {
@@ -6900,7 +6900,7 @@
 			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -6908,8 +6908,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					}
 				},
 				"is-extendable": {
@@ -6917,7 +6917,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -6934,14 +6934,14 @@
 			"integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.3",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.1",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.1",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"stack-trace": {
@@ -6972,8 +6972,8 @@
 			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6981,7 +6981,7 @@
 					"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -6998,7 +6998,7 @@
 			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
 			"dev": true,
 			"requires": {
-				"duplexer": "~0.1.1"
+				"duplexer": "0.1.1"
 			}
 		},
 		"stream-shift": {
@@ -7013,7 +7013,7 @@
 			"integrity": "sha512-Gk6KZM+yNA1JpW0KzlZIhjo3EaBJDkYfXtYSbOwNIQ7Zd6006E6+sCFlW1NDvFG/vnXhKmw6TJJgiEQg/8lXfQ==",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.2"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"streamifier": {
@@ -7034,8 +7034,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -7050,7 +7050,7 @@
 					"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^3.0.0"
+						"ansi-regex": "3.0.0"
 					}
 				}
 			}
@@ -7060,9 +7060,9 @@
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"requires": {
-				"code-point-at": "^1.0.0",
-				"is-fullwidth-code-point": "^1.0.0",
-				"strip-ansi": "^3.0.0"
+				"code-point-at": "1.1.0",
+				"is-fullwidth-code-point": "1.0.0",
+				"strip-ansi": "3.0.1"
 			}
 		},
 		"string_decoder": {
@@ -7070,7 +7070,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"stringify-object": {
@@ -7079,9 +7079,9 @@
 			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
 			"dev": true,
 			"requires": {
-				"get-own-enumerable-property-symbols": "^3.0.0",
-				"is-obj": "^1.0.1",
-				"is-regexp": "^1.0.0"
+				"get-own-enumerable-property-symbols": "3.0.0",
+				"is-obj": "1.0.1",
+				"is-regexp": "1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -7089,7 +7089,7 @@
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"strip-bom": {
@@ -7098,7 +7098,7 @@
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"dev": true,
 			"requires": {
-				"is-utf8": "^0.2.0"
+				"is-utf8": "0.2.1"
 			}
 		},
 		"strip-bom-stream": {
@@ -7107,8 +7107,8 @@
 			"integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
 			"dev": true,
 			"requires": {
-				"first-chunk-stream": "^1.0.0",
-				"strip-bom": "^2.0.0"
+				"first-chunk-stream": "1.0.0",
+				"strip-bom": "2.0.0"
 			}
 		},
 		"strip-eof": {
@@ -7123,7 +7123,7 @@
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "3.0.0"
 			},
 			"dependencies": {
 				"has-flag": {
@@ -7152,9 +7152,9 @@
 			"integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
 			"dev": true,
 			"requires": {
-				"block-stream": "*",
-				"fstream": "^1.0.2",
-				"inherits": "2"
+				"block-stream": "0.0.9",
+				"fstream": "1.0.11",
+				"inherits": "2.0.3"
 			}
 		},
 		"test-exclude": {
@@ -7163,11 +7163,11 @@
 			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
-				"require-main-filename": "^1.0.1"
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
 			}
 		},
 		"text-hex": {
@@ -7193,8 +7193,8 @@
 			"integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.1.5",
-				"xtend": "~4.0.1"
+				"readable-stream": "2.3.6",
+				"xtend": "4.0.1"
 			}
 		},
 		"through2-filter": {
@@ -7203,8 +7203,8 @@
 			"integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
 			"dev": true,
 			"requires": {
-				"through2": "~2.0.0",
-				"xtend": "~4.0.0"
+				"through2": "2.0.3",
+				"xtend": "4.0.1"
 			}
 		},
 		"tmpl": {
@@ -7219,7 +7219,7 @@
 			"integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1"
+				"extend-shallow": "2.0.1"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -7228,7 +7228,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -7244,7 +7244,7 @@
 			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7252,7 +7252,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -7262,10 +7262,10 @@
 			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -7273,8 +7273,8 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
 					"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 					"requires": {
-						"assign-symbols": "^1.0.0",
-						"is-extendable": "^1.0.1"
+						"assign-symbols": "1.0.0",
+						"is-extendable": "1.0.1"
 					}
 				},
 				"is-extendable": {
@@ -7282,7 +7282,7 @@
 					"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -7292,8 +7292,8 @@
 			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -7301,7 +7301,7 @@
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				},
 				"kind-of": {
@@ -7309,7 +7309,7 @@
 					"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -7320,7 +7320,7 @@
 			"integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.4.1"
+				"punycode": "1.4.1"
 			}
 		},
 		"tr46": {
@@ -7329,7 +7329,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -7357,14 +7357,14 @@
 			"integrity": "sha512-oV/wBwGUS7olSk/9yWMiSIJWbz5xO4zhftnY3gwv6s4SMg6WHF1m8XZNBvQOKQRiTAexZ9754Z13dxBq3Zgssw==",
 			"dev": true,
 			"requires": {
-				"bs-logger": "0.x",
-				"buffer-from": "1.x",
-				"fast-json-stable-stringify": "2.x",
-				"json5": "2.x",
-				"make-error": "1.x",
-				"mkdirp": "0.x",
-				"semver": "^5.5",
-				"yargs-parser": "10.x"
+				"bs-logger": "0.2.5",
+				"buffer-from": "1.0.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json5": "2.1.0",
+				"make-error": "1.3.5",
+				"mkdirp": "0.5.1",
+				"semver": "5.5.0",
+				"yargs-parser": "10.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -7379,7 +7379,7 @@
 					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
+						"minimist": "1.2.0"
 					}
 				},
 				"minimist": {
@@ -7394,7 +7394,7 @@
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -7411,18 +7411,18 @@
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.22.0",
-				"builtin-modules": "^1.1.1",
-				"chalk": "^2.3.0",
-				"commander": "^2.12.1",
-				"diff": "^3.2.0",
-				"glob": "^7.1.1",
-				"js-yaml": "^3.7.0",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.3.2",
-				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
-				"tsutils": "^2.27.2"
+				"babel-code-frame": "6.26.0",
+				"builtin-modules": "1.1.1",
+				"chalk": "2.4.1",
+				"commander": "2.17.1",
+				"diff": "3.3.1",
+				"glob": "7.1.2",
+				"js-yaml": "3.12.0",
+				"minimatch": "3.0.4",
+				"resolve": "1.8.1",
+				"semver": "5.5.0",
+				"tslib": "1.9.3",
+				"tsutils": "2.29.0"
 			},
 			"dependencies": {
 				"resolve": {
@@ -7431,7 +7431,7 @@
 					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 					"dev": true,
 					"requires": {
-						"path-parse": "^1.0.5"
+						"path-parse": "1.0.6"
 					}
 				}
 			}
@@ -7442,7 +7442,7 @@
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.8.1"
+				"tslib": "1.9.3"
 			}
 		},
 		"tunnel": {
@@ -7456,7 +7456,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -7472,7 +7472,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"type-detect": {
@@ -7503,8 +7503,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.17.1",
-				"source-map": "~0.6.1"
+				"commander": "2.17.1",
+				"source-map": "0.6.1"
 			}
 		},
 		"underscore": {
@@ -7517,10 +7517,10 @@
 			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"arr-union": {
@@ -7533,7 +7533,7 @@
 					"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -7541,10 +7541,10 @@
 					"resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -7555,8 +7555,8 @@
 			"integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
 			"dev": true,
 			"requires": {
-				"json-stable-stringify": "^1.0.0",
-				"through2-filter": "^2.0.0"
+				"json-stable-stringify": "1.0.1",
+				"through2-filter": "2.0.0"
 			}
 		},
 		"unset-value": {
@@ -7564,8 +7564,8 @@
 			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -7573,9 +7573,9 @@
 					"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -7617,8 +7617,8 @@
 			"integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
 			"dev": true,
 			"requires": {
-				"querystringify": "^2.0.0",
-				"requires-port": "^1.0.0"
+				"querystringify": "2.0.0",
+				"requires-port": "1.0.0"
 			}
 		},
 		"use": {
@@ -7626,7 +7626,7 @@
 			"resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
 			"integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
 			"requires": {
-				"kind-of": "^6.0.2"
+				"kind-of": "6.0.2"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -7647,8 +7647,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.3",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"uuid": {
@@ -7669,8 +7669,8 @@
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.2",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"verror": {
@@ -7679,9 +7679,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vinyl": {
@@ -7690,8 +7690,8 @@
 			"integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
 			"dev": true,
 			"requires": {
-				"clone": "^0.2.0",
-				"clone-stats": "^0.0.1"
+				"clone": "0.2.0",
+				"clone-stats": "0.0.1"
 			}
 		},
 		"vinyl-fs": {
@@ -7700,23 +7700,23 @@
 			"integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
 			"dev": true,
 			"requires": {
-				"duplexify": "^3.2.0",
-				"glob-stream": "^5.3.2",
-				"graceful-fs": "^4.0.0",
+				"duplexify": "3.6.0",
+				"glob-stream": "5.3.5",
+				"graceful-fs": "4.1.11",
 				"gulp-sourcemaps": "1.6.0",
-				"is-valid-glob": "^0.3.0",
-				"lazystream": "^1.0.0",
-				"lodash.isequal": "^4.0.0",
-				"merge-stream": "^1.0.0",
-				"mkdirp": "^0.5.0",
-				"object-assign": "^4.0.0",
-				"readable-stream": "^2.0.4",
-				"strip-bom": "^2.0.0",
-				"strip-bom-stream": "^1.0.0",
-				"through2": "^2.0.0",
-				"through2-filter": "^2.0.0",
-				"vali-date": "^1.0.0",
-				"vinyl": "^1.0.0"
+				"is-valid-glob": "0.3.0",
+				"lazystream": "1.0.0",
+				"lodash.isequal": "4.5.0",
+				"merge-stream": "1.0.1",
+				"mkdirp": "0.5.1",
+				"object-assign": "4.1.1",
+				"readable-stream": "2.3.6",
+				"strip-bom": "2.0.0",
+				"strip-bom-stream": "1.0.0",
+				"through2": "2.0.3",
+				"through2-filter": "2.0.0",
+				"vali-date": "1.0.0",
+				"vinyl": "1.2.0"
 			},
 			"dependencies": {
 				"clone": {
@@ -7737,8 +7737,8 @@
 					"integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
 					"dev": true,
 					"requires": {
-						"clone": "^1.0.0",
-						"clone-stats": "^0.0.1",
+						"clone": "1.0.4",
+						"clone-stats": "0.0.1",
 						"replace-ext": "0.0.1"
 					}
 				}
@@ -7750,8 +7750,8 @@
 			"integrity": "sha1-YrU6E1YQqJbpjKlr7jqH8Aio54A=",
 			"dev": true,
 			"requires": {
-				"through2": "^2.0.3",
-				"vinyl": "^0.4.3"
+				"through2": "2.0.3",
+				"vinyl": "0.4.6"
 			}
 		},
 		"vscode": {
@@ -7760,20 +7760,20 @@
 			"integrity": "sha512-tJl9eL15ZMm6vzCYYeQ26sSYRuXGMGPsaeIAmG2rOOYRn01jdaDg6I4b9G5Ed6FISdmn6egpKThk4o4om8Ax/A==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.1.2",
-				"gulp-chmod": "^2.0.0",
-				"gulp-filter": "^5.0.1",
+				"glob": "7.1.2",
+				"gulp-chmod": "2.0.0",
+				"gulp-filter": "5.1.0",
 				"gulp-gunzip": "1.0.0",
-				"gulp-remote-src-vscode": "^0.5.0",
-				"gulp-symdest": "^1.1.0",
-				"gulp-untar": "^0.0.7",
-				"gulp-vinyl-zip": "^2.1.0",
-				"mocha": "^4.0.1",
-				"request": "^2.83.0",
-				"semver": "^5.4.1",
-				"source-map-support": "^0.5.0",
-				"url-parse": "^1.4.3",
-				"vinyl-source-stream": "^1.1.0"
+				"gulp-remote-src-vscode": "0.5.0",
+				"gulp-symdest": "1.1.0",
+				"gulp-untar": "0.0.7",
+				"gulp-vinyl-zip": "2.1.0",
+				"mocha": "4.1.0",
+				"request": "2.87.0",
+				"semver": "5.5.0",
+				"source-map-support": "0.5.6",
+				"url-parse": "1.4.3",
+				"vinyl-source-stream": "1.1.2"
 			}
 		},
 		"vscode-jsonrpc": {
@@ -7809,7 +7809,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.3"
 			}
 		},
 		"walker": {
@@ -7818,7 +7818,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"watch": {
@@ -7827,8 +7827,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.2.2",
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -7866,9 +7866,9 @@
 			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"which": {
@@ -7877,7 +7877,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -7896,15 +7896,15 @@
 			"resolved": "https://registry.npmjs.org/winston/-/winston-3.1.0.tgz",
 			"integrity": "sha512-FsQfEE+8YIEeuZEYhHDk5cILo1HOcWkGwvoidLrDgPog0r4bser1lEIOco2dN9zpDJ1M88hfDgZvxe5z4xNcwg==",
 			"requires": {
-				"async": "^2.6.0",
-				"diagnostics": "^1.1.1",
-				"is-stream": "^1.1.0",
-				"logform": "^1.9.1",
+				"async": "2.6.1",
+				"diagnostics": "1.1.1",
+				"is-stream": "1.1.0",
+				"logform": "1.10.0",
 				"one-time": "0.0.4",
-				"readable-stream": "^2.3.6",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.2.0"
+				"readable-stream": "2.3.6",
+				"stack-trace": "0.0.10",
+				"triple-beam": "1.3.0",
+				"winston-transport": "4.2.0"
 			}
 		},
 		"winston-transport": {
@@ -7912,8 +7912,8 @@
 			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
 			"integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
 			"requires": {
-				"readable-stream": "^2.3.6",
-				"triple-beam": "^1.2.0"
+				"readable-stream": "2.3.6",
+				"triple-beam": "1.3.0"
 			}
 		},
 		"wordwrap": {
@@ -7927,8 +7927,8 @@
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			}
 		},
 		"wrappy": {
@@ -7943,9 +7943,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ws": {
@@ -7954,7 +7954,7 @@
 			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0"
+				"async-limiter": "1.0.0"
 			}
 		},
 		"xml-name-validator": {
@@ -7985,13 +7985,13 @@
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
 			"integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
 			"requires": {
-				"camelcase": "^2.0.1",
-				"cliui": "^3.0.3",
-				"decamelize": "^1.1.1",
-				"os-locale": "^1.4.0",
-				"string-width": "^1.0.1",
-				"window-size": "^0.1.4",
-				"y18n": "^3.2.0"
+				"camelcase": "2.1.1",
+				"cliui": "3.2.0",
+				"decamelize": "1.2.0",
+				"os-locale": "1.4.0",
+				"string-width": "1.0.2",
+				"window-size": "0.1.4",
+				"y18n": "3.2.1"
 			}
 		},
 		"yargs-parser": {
@@ -8000,7 +8000,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			},
 			"dependencies": {
 				"camelcase": {
@@ -8017,8 +8017,8 @@
 			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "~0.2.3",
-				"fd-slicer": "~1.1.0"
+				"buffer-crc32": "0.2.13",
+				"fd-slicer": "1.1.0"
 			}
 		},
 		"yazl": {
@@ -8027,7 +8027,7 @@
 			"integrity": "sha1-7CblzIfVYBud+EMtvdPNLlFzoHE=",
 			"dev": true,
 			"requires": {
-				"buffer-crc32": "~0.2.3"
+				"buffer-crc32": "0.2.13"
 			}
 		}
 	}

--- a/client/resources/qiskitScripts/executeQASM.py
+++ b/client/resources/qiskitScripts/executeQASM.py
@@ -3,9 +3,9 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-import warnings
-from marshmallow.warnings import ChangedInMarshmallow3Warning
-warnings.simplefilter('ignore', category=ChangedInMarshmallow3Warning)
+import warnings  # noqa
+from marshmallow.warnings import ChangedInMarshmallow3Warning  # noqa
+warnings.simplefilter('ignore', category=ChangedInMarshmallow3Warning)  # noqa
 
 from qiskitTools import QiskitTools
 import os

--- a/client/resources/qiskitScripts/executeQASM.py
+++ b/client/resources/qiskitScripts/executeQASM.py
@@ -3,12 +3,22 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
-from packaging import version
-import argparse
-import json
-import subprocess
-import os
+import warnings
+
+def showwarning(message, category, filename, lineno, file, line):
+    # print(message)
+    # print(filename)
+    pass
+
+warnings.showwarning = showwarning
+warnings.resetwarnings()  # allow all warnings
+
 from qiskitTools import QiskitTools
+import os
+import subprocess
+import json
+import argparse
+from packaging import version
 
 
 def main():

--- a/client/resources/qiskitScripts/executeQASM.py
+++ b/client/resources/qiskitScripts/executeQASM.py
@@ -4,14 +4,8 @@
 # the LICENSE.txt file in the root directory of this source tree.
 
 import warnings
-
-def showwarning(message, category, filename, lineno, file, line):
-    # print(message)
-    # print(filename)
-    pass
-
-warnings.showwarning = showwarning
-warnings.resetwarnings()  # allow all warnings
+from marshmallow.warnings import ChangedInMarshmallow3Warning
+warnings.simplefilter('ignore', category=ChangedInMarshmallow3Warning)
 
 from qiskitTools import QiskitTools
 import os

--- a/client/resources/qiskitScripts/getQueueStatus.py
+++ b/client/resources/qiskitScripts/getQueueStatus.py
@@ -3,6 +3,10 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+import warnings  # noqa
+from marshmallow.warnings import ChangedInMarshmallow3Warning  # noqa
+warnings.simplefilter('ignore', category=ChangedInMarshmallow3Warning)  # noqa
+
 import warnings
 import json
 import argparse

--- a/client/resources/qiskitScripts/listLocalBackends.py
+++ b/client/resources/qiskitScripts/listLocalBackends.py
@@ -2,6 +2,11 @@
 #
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
+
+import warnings  # noqa
+from marshmallow.warnings import ChangedInMarshmallow3Warning  # noqa
+warnings.simplefilter('ignore', category=ChangedInMarshmallow3Warning)  # noqa
+
 import warnings
 import json
 from qiskit import __version__

--- a/client/resources/qiskitScripts/listRemoteBackends.py
+++ b/client/resources/qiskitScripts/listRemoteBackends.py
@@ -3,6 +3,10 @@
 # This source code is licensed under the Apache License, Version 2.0 found in
 # the LICENSE.txt file in the root directory of this source tree.
 
+import warnings  # noqa
+from marshmallow.warnings import ChangedInMarshmallow3Warning  # noqa
+warnings.simplefilter('ignore', category=ChangedInMarshmallow3Warning)  # noqa
+
 from qiskit import __version__
 from packaging import version
 import argparse

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -1,3 +1,4 @@
+from qiskit import QuantumCircuit
 import json
 from qiskit import __version__
 from IBMQuantumExperience import IBMQuantumExperience
@@ -10,6 +11,9 @@ from qiskit import execute
 if (version.parse(__version__) >= version.parse("0.6")):
     from qiskit import IBMQ
     from qiskit import Aer
+
+if (version.parse(__version__) >= version.parse("0.7")):
+    from qiskit import QuantumCircuit
 
 
 class QiskitUnsupportedVersion(Exception):
@@ -48,9 +52,15 @@ class QiskitTools(object):
             result = job_sim.result()
             return result.get_counts()
 
+        elif (version.parse(__version__) >= version.parse("0.7")):
+            qc = QuantumCircuit.from_qasm_file(filename)
+            job_sim = execute(qc, Aer.get_backend("qasm_simulator"))
+            result = job_sim.result()
+            return result.get_counts()
+
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.6')
+                'Qiskit-terra version must be v0.6 or v0.7')
 
     def listRemoteBackends(self, apiToken, url,
                            hub=None, group=None, project=None):

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -1,3 +1,8 @@
+# Copyright (c) 2018, IBM.
+#
+# This source code is licensed under the Apache License, Version 2.0 found in
+# the LICENSE.txt file in the root directory of this source tree.
+
 import json
 from qiskit import __version__
 from IBMQuantumExperience import IBMQuantumExperience

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -125,16 +125,26 @@ class QiskitTools(object):
                 )
             }
 
+    def parseBackendStatus(self, backendStatus):
+        if (version.parse(__version__) >= version.parse("0.6") and
+                (version.parse(__version__) < version.parse("0.7"))):
+            return {
+                'name': backendStatus['name'],
+                'pending_jobs': backendStatus['pending_jobs'],
+                'available': self.parseAvailability(backendStatus)
+            }
+        elif (version.parse(__version__) >= version.parse("0.7")):
+            # The type(backendStatus) is now <class 'qiskit.providers.models.backendstatus.BackendStatus'>
+            # previously was <class 'qiskit._util.AvailableToOperationalDict'>
+            return {
+                'name': backendStatus.backend_name,
+                'pending_jobs': backendStatus.pending_jobs,
+                'available': backendStatus.operational
+            }
+
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.6')
-
-    def parseBackendStatus(self, backendStatus):
-        return {
-            'name': backendStatus['name'],
-            'pending_jobs': backendStatus['pending_jobs'],
-            'available': self.parseAvailability(backendStatus)
-        }
+                'Qiskit-terra version must be v0.6 or v0.7')
 
     def parseAvailability(self, backendStatus):
         try:

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -1,19 +1,16 @@
-from qiskit import QuantumCircuit
 import json
 from qiskit import __version__
 from IBMQuantumExperience import IBMQuantumExperience
 from packaging import version
 import argparse
 import warnings
+from qiskit import QuantumCircuit
 from qiskit.wrapper import load_qasm_file
 from qiskit import execute
 
 if (version.parse(__version__) >= version.parse("0.6")):
     from qiskit import IBMQ
     from qiskit import Aer
-
-if (version.parse(__version__) >= version.parse("0.7")):
-    from qiskit import QuantumCircuit
 
 
 class QiskitUnsupportedVersion(Exception):

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -116,14 +116,12 @@ class QiskitTools(object):
                 'Qiskit-terra version must be v0.6 or v0.7')
 
     def createDeviceStatus(self, back):
-        if (version.parse(__version__) >= version.parse("0.6") and
-                (version.parse(__version__) < version.parse("0.7"))):
-            return {
-                'name': self.PUBLIC_NAMES[back],
-                'status': self.parseBackendStatus(
-                    IBMQ.get_backend(back).status()
-                )
-            }
+        return {
+            'name': self.PUBLIC_NAMES[back],
+            'status': self.parseBackendStatus(
+                IBMQ.get_backend(back).status()
+            )
+        }
 
     def parseBackendStatus(self, backendStatus):
         if (version.parse(__version__) >= version.parse("0.6") and

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -66,7 +66,7 @@ class QiskitTools(object):
                            hub=None, group=None, project=None):
 
         if (version.parse(__version__) >= version.parse("0.6") and
-                (version.parse(__version__) < version.parse("0.7"))):
+                (version.parse(__version__) <= version.parse("0.7"))):
 
             if (hub is None or group is None or project is None):
                 IBMQ.enable_account(apiToken, url)
@@ -79,26 +79,26 @@ class QiskitTools(object):
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.6')
+                'Qiskit-terra version must be v0.6 or v0.7')
 
         return backs
 
     def listLocalBackends(self):
 
         if (version.parse(__version__) >= version.parse("0.6") and
-                (version.parse(__version__) < version.parse("0.7"))):
+                (version.parse(__version__) <= version.parse("0.7"))):
             backs = [backend.name() for backend in Aer.backends()]
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.6')
+                'Qiskit-terra version must be v0.6 or v0.7')
 
         return backs
 
     def getBackendStatus(self, back, apiToken, url,
                          hub=None, group=None, project=None):
         if (version.parse(__version__) >= version.parse("0.6") and
-                (version.parse(__version__) < version.parse("0.7"))):
+                (version.parse(__version__) <= version.parse("0.7"))):
 
             if (hub is None or group is None or project is None):
                 IBMQ.enable_account(apiToken, url)
@@ -111,7 +111,7 @@ class QiskitTools(object):
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.6')
+                'Qiskit-terra version must be v0.6 or v0.7')
 
     def createDeviceStatus(self, back):
         if (version.parse(__version__) >= version.parse("0.6") and

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -7,10 +7,6 @@ import warnings
 from qiskit.wrapper import load_qasm_file
 from qiskit import execute
 
-if (version.parse(__version__) > version.parse("0.5") and
-        version.parse(__version__) < version.parse("0.6")):
-    from qiskit import register, available_backends, get_backend
-
 if (version.parse(__version__) > version.parse("0.6")):
     from qiskit import IBMQ
     from qiskit import Aer
@@ -45,15 +41,7 @@ class QiskitTools(object):
 
     def executeQASM(self, filename):
 
-        if (version.parse(__version__) > version.parse("0.5") and
-                version.parse(__version__) < version.parse("0.6")):
-
-            qc = load_qasm_file(filename)
-            job_sim = execute(qc, "local_qasm_simulator")
-            result = job_sim.result()
-            return result._result
-
-        elif (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) > version.parse("0.6")):
 
             qc = load_qasm_file(filename)
             job_sim = execute(qc, Aer.get_backend("qasm_simulator"))
@@ -62,22 +50,12 @@ class QiskitTools(object):
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.5 or v0.6')
+                'Qiskit-terra version must be v0.6')
 
     def listRemoteBackends(self, apiToken, url,
                            hub=None, group=None, project=None):
 
-        if (version.parse(__version__) > version.parse("0.5") and
-                version.parse(__version__) < version.parse("0.6")):
-
-            if (hub is None or group is None or project is None):
-                register(apiToken, url)
-            else:
-                register(apiToken, url, hub, group, project)
-
-            backs = available_backends({'local': False})
-
-        elif (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) > version.parse("0.6")):
 
             if (hub is None or group is None or project is None):
                 IBMQ.enable_account(apiToken, url)
@@ -90,44 +68,24 @@ class QiskitTools(object):
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.5 or v0.6')
+                'Qiskit-terra version must be v0.6')
 
         return backs
 
     def listLocalBackends(self):
 
-        if (version.parse(__version__) > version.parse("0.5")
-                and version.parse(__version__) < version.parse("0.6")):
-            backs = available_backends({'local': True})
-
-        elif (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) > version.parse("0.6")):
             backs = [backend.name() for backend in Aer.backends()]
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.5 or v0.6')
+                'Qiskit-terra version must be v0.6')
 
         return backs
 
     def getBackendStatus(self, back, apiToken, url,
                          hub=None, group=None, project=None):
-        if (version.parse(__version__) > version.parse("0.5") and
-                version.parse(__version__) < version.parse("0.6")):
-
-            if (hub is None or group is None
-                    or project is None):
-                api = IBMQuantumExperience(
-                    apiToken, {'url': url})
-            else:
-                api = IBMQuantumExperience(apiToken,
-                                           {'url': url,
-                                            'hub': hub,
-                                            'group': group,
-                                            'project': project})
-
-            return api.backend_status(back)
-
-        elif (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) > version.parse("0.6")):
 
             if (hub is None or group is None or project is None):
                 IBMQ.enable_account(apiToken, url)
@@ -140,17 +98,10 @@ class QiskitTools(object):
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.5 or v0.6')
+                'Qiskit-terra version must be v0.6')
 
     def createDeviceStatus(self, back):
-        if (version.parse(__version__) > version.parse("0.5") and
-                version.parse(__version__) < version.parse("0.6")):
-            return {
-                'name': self.PUBLIC_NAMES[back],
-                'status': self.parseBackendStatus(get_backend(back).status)
-            }
-
-        elif (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) > version.parse("0.6")):
             return {
                 'name': self.PUBLIC_NAMES[back],
                 'status': self.parseBackendStatus(
@@ -160,7 +111,7 @@ class QiskitTools(object):
 
         else:
             raise QiskitUnsupportedVersion(
-                'Qiskit-terra version must be v0.5 or v0.6')
+                'Qiskit-terra version must be v0.6')
 
     def parseBackendStatus(self, backendStatus):
         return {

--- a/client/resources/qiskitScripts/qiskitTools.py
+++ b/client/resources/qiskitScripts/qiskitTools.py
@@ -7,7 +7,7 @@ import warnings
 from qiskit.wrapper import load_qasm_file
 from qiskit import execute
 
-if (version.parse(__version__) > version.parse("0.6")):
+if (version.parse(__version__) >= version.parse("0.6")):
     from qiskit import IBMQ
     from qiskit import Aer
 
@@ -40,8 +40,8 @@ class QiskitTools(object):
         }
 
     def executeQASM(self, filename):
-
-        if (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) >= version.parse("0.6") and
+                (version.parse(__version__) < version.parse("0.7"))):
 
             qc = load_qasm_file(filename)
             job_sim = execute(qc, Aer.get_backend("qasm_simulator"))
@@ -55,7 +55,8 @@ class QiskitTools(object):
     def listRemoteBackends(self, apiToken, url,
                            hub=None, group=None, project=None):
 
-        if (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) >= version.parse("0.6") and
+                (version.parse(__version__) < version.parse("0.7"))):
 
             if (hub is None or group is None or project is None):
                 IBMQ.enable_account(apiToken, url)
@@ -74,7 +75,8 @@ class QiskitTools(object):
 
     def listLocalBackends(self):
 
-        if (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) >= version.parse("0.6") and
+                (version.parse(__version__) < version.parse("0.7"))):
             backs = [backend.name() for backend in Aer.backends()]
 
         else:
@@ -85,7 +87,8 @@ class QiskitTools(object):
 
     def getBackendStatus(self, back, apiToken, url,
                          hub=None, group=None, project=None):
-        if (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) >= version.parse("0.6") and
+                (version.parse(__version__) < version.parse("0.7"))):
 
             if (hub is None or group is None or project is None):
                 IBMQ.enable_account(apiToken, url)
@@ -101,7 +104,8 @@ class QiskitTools(object):
                 'Qiskit-terra version must be v0.6')
 
     def createDeviceStatus(self, back):
-        if (version.parse(__version__) > version.parse("0.6")):
+        if (version.parse(__version__) >= version.parse("0.6") and
+                (version.parse(__version__) < version.parse("0.7"))):
             return {
                 'name': self.PUBLIC_NAMES[back],
                 'status': self.parseBackendStatus(

--- a/client/src/commandExecutor.ts
+++ b/client/src/commandExecutor.ts
@@ -80,6 +80,9 @@ export namespace CommandExecutor {
                 //console.log(document);
                 //console.log("python", [document.fileName.toString(), '--file', codeFile.fileName.toString()]);
 
+                // Working filters to ignore the warnings:
+                // - python -W ignore -> Filter all the warnings raised during the execution of the file
+                // - python -W ignore::::364 -> Filter the warnings raised by the line 364 of any module
                 CommandExecutor.exec('python', [document.fileName.toString(), '--file', codeFile.fileName.toString()])
                     .then(stdout => {
                         //console.log(stdout);

--- a/client/src/commandExecutor.ts
+++ b/client/src/commandExecutor.ts
@@ -73,19 +73,13 @@ export namespace CommandExecutor {
             const codeFile = vscode.window.activeTextEditor.document;
             codeFile.save();
 
-            //console.log("Let's go to execute that QASM")
-            //console.log(execPath);
-
             vscode.workspace.openTextDocument(execPath).then(document => {
-                //console.log(document);
-                //console.log("python", [document.fileName.toString(), '--file', codeFile.fileName.toString()]);
-
                 // Working filters to ignore the warnings:
                 // - python -W ignore -> Filter all the warnings raised during the execution of the file
                 // - python -W ignore::::364 -> Filter the warnings raised by the line 364 of any module
                 CommandExecutor.exec('python', [document.fileName.toString(), '--file', codeFile.fileName.toString()])
                     .then(stdout => {
-                        //console.log(stdout);
+                        //vscode.window.showInformationMessage(stdout);
                         return resolve(stdout);
                     })
                     .catch(err => {
@@ -106,7 +100,6 @@ export namespace CommandExecutor {
             vscode.workspace.openTextDocument(execPath).then(document => {
                 CommandExecutor.exec('python', [document.fileName.toString()].concat(options))
                     .then(stdout => {
-                        // console.log(stdout);
                         //vscode.window.showInformationMessage("Execution result:",stdout);
                         return resolve(stdout);
                     })

--- a/client/src/commandExecutor.ts
+++ b/client/src/commandExecutor.ts
@@ -53,7 +53,25 @@ export namespace CommandExecutor {
             vscode.window.showInformationMessage('⚡ Running... ⚡');
             const codeFile = vscode.window.activeTextEditor.document;
             codeFile.save();
-            CommandExecutor.exec('python', [codeFile.fileName.toString()])
+            /* The following workaround is intended to omit the warning "ChangedInMarshmallow3Warning" raised by marshmallow module when using Qiskit 0.7
+            The full warning raised by the module is something like:
+            
+            /path/site-packages/marshmallow/schema.py:364: ChangedInMarshmallow3Warning: strict=False is not recommended. In marshmallow 3.0, schemas will always be strict. See https://marshmallow.readthedocs.io/en/latest/upgrading.html#schemas-are-always-strict
+  ChangedInMarshmallow3Warning
+            
+            So, to omit it, we launch the python execution filtering all the warnings which begins with the message "strict=False is not recommended. In marshmallow 3.0""
+            We tried, but didn't succeed, to filter by module .*marshmallow.* and by category "ChangedInMarshmallow3Warning" (not possible due it is not a direct subclass of Python Warnings)
+            
+            Qiskit v0.8 should omit this warning by itself. Then, we should remove the current workaround.
+            More info: 
+              - https://github.com/Qiskit/qiskit-terra/commit/11b69e4e620d02994b95a5fad925833011202342#diff-1cbb089c669bc3c7d5b9189badd019f8R56
+              - https://github.com/Qiskit/qiskit-terra/pull/1695
+              - https://github.com/marshmallow-code/marshmallow/blob/2.x-line/marshmallow/schema.py#L364
+            */
+
+            CommandExecutor.exec('python -W ignore:"strict=False is not recommended. In marshmallow 3.0"', [
+                codeFile.fileName.toString()
+            ])
                 .then(stdout => {
                     return resolve(stdout);
                 })

--- a/docs/support/SDR-001.md
+++ b/docs/support/SDR-001.md
@@ -1,0 +1,19 @@
+# 1. The extension should support only the current Qiskit-Terra version and a previous one.
+
+Date: 2019-01-23
+
+## Status
+
+Accepted
+
+## Context
+
+Qiskit-vscode is tied to Qiskit libraries, mainly to Qiskit Terra. Qiskit Terra is currently below version 1.0 and experiences many changes in the API each time is upgraded. We must decide how many different versions of the Qiskit Terra's API we support.
+
+## Decision
+
+As decided by the authors and part of the Qiskit core team, we will support the current version of Qiskit Terra and a previous one. Example: currently, the last version is v0.7.X and we will support v0.7.X and v0.6.X.
+
+## Consequences
+
+When Qiskit Terra achieves a stable version, we will need to review this policy.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"dev": true,
 			"requires": {
-				"color-convert": "^1.9.0"
+				"color-convert": "1.9.1"
 			}
 		},
 		"array-filter": {
@@ -49,7 +49,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -65,9 +65,9 @@
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.4.0"
 			}
 		},
 		"color-convert": {
@@ -76,7 +76,7 @@
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"dev": true,
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -97,11 +97,11 @@
 			"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 			"dev": true,
 			"requires": {
-				"nice-try": "^1.0.4",
-				"path-key": "^2.0.1",
-				"semver": "^5.5.0",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"nice-try": "1.0.4",
+				"path-key": "2.0.1",
+				"semver": "5.5.0",
+				"shebang-command": "1.2.0",
+				"which": "1.3.1"
 			}
 		},
 		"define-properties": {
@@ -110,8 +110,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
 			}
 		},
 		"duplexer": {
@@ -126,7 +126,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -135,11 +135,11 @@
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -148,9 +148,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -165,13 +165,13 @@
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
 				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
 			}
 		},
 		"foreach": {
@@ -204,7 +204,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.0.2"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-flag": {
@@ -231,7 +231,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -252,7 +252,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"is-symbol": {
@@ -285,10 +285,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "4.0.0",
+				"pify": "3.0.0",
+				"strip-bom": "3.0.0"
 			}
 		},
 		"map-stream": {
@@ -309,7 +309,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"nice-try": {
@@ -324,10 +324,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"npm-run-all": {
@@ -336,15 +336,15 @@
 			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.4",
-				"memorystream": "^0.3.1",
-				"minimatch": "^3.0.4",
-				"ps-tree": "^1.1.0",
-				"read-pkg": "^3.0.0",
-				"shell-quote": "^1.6.1",
-				"string.prototype.padend": "^3.0.0"
+				"ansi-styles": "3.2.1",
+				"chalk": "2.4.1",
+				"cross-spawn": "6.0.5",
+				"memorystream": "0.3.1",
+				"minimatch": "3.0.4",
+				"ps-tree": "1.1.0",
+				"read-pkg": "3.0.0",
+				"shell-quote": "1.6.1",
+				"string.prototype.padend": "3.0.0"
 			}
 		},
 		"object-keys": {
@@ -359,8 +359,8 @@
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
+				"error-ex": "1.3.1",
+				"json-parse-better-errors": "1.0.2"
 			}
 		},
 		"path-key": {
@@ -375,7 +375,7 @@
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			}
 		},
 		"pause-stream": {
@@ -384,7 +384,7 @@
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
 			"dev": true,
 			"requires": {
-				"through": "~2.3"
+				"through": "2.3.8"
 			}
 		},
 		"pify": {
@@ -399,7 +399,7 @@
 			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
 			"dev": true,
 			"requires": {
-				"event-stream": "~3.3.0"
+				"event-stream": "3.3.4"
 			}
 		},
 		"read-pkg": {
@@ -408,9 +408,9 @@
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
+				"load-json-file": "4.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "3.0.0"
 			}
 		},
 		"semver": {
@@ -425,7 +425,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -440,10 +440,10 @@
 			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
 			"dev": true,
 			"requires": {
-				"array-filter": "~0.0.0",
-				"array-map": "~0.0.0",
-				"array-reduce": "~0.0.0",
-				"jsonify": "~0.0.0"
+				"array-filter": "0.0.1",
+				"array-map": "0.0.0",
+				"array-reduce": "0.0.0",
+				"jsonify": "0.0.0"
 			}
 		},
 		"spdx-correct": {
@@ -452,8 +452,8 @@
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -468,8 +468,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -484,7 +484,7 @@
 			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
 			"dev": true,
 			"requires": {
-				"through": "2"
+				"through": "2.3.8"
 			}
 		},
 		"stream-combiner": {
@@ -493,7 +493,7 @@
 			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
 			"dev": true,
 			"requires": {
-				"duplexer": "~0.1.1"
+				"duplexer": "0.1.1"
 			}
 		},
 		"string.prototype.padend": {
@@ -502,9 +502,9 @@
 			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.4.3",
-				"function-bind": "^1.0.2"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.12.0",
+				"function-bind": "1.1.1"
 			}
 		},
 		"strip-bom": {
@@ -519,7 +519,7 @@
 			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "3.0.0"
 			}
 		},
 		"through": {
@@ -540,8 +540,8 @@
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"which": {
@@ -550,7 +550,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		}
 	}

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,7 +10,7 @@
 			"integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "7.0.0"
 			}
 		},
 		"@babel/highlight": {
@@ -19,9 +19,9 @@
 			"integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^4.0.0"
+				"chalk": "2.3.2",
+				"esutils": "2.0.2",
+				"js-tokens": "4.0.0"
 			},
 			"dependencies": {
 				"js-tokens": {
@@ -38,7 +38,7 @@
 			"integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
 			"dev": true,
 			"requires": {
-				"any-observable": "^0.3.0"
+				"any-observable": "0.3.0"
 			}
 		},
 		"@types/jest": {
@@ -65,8 +65,8 @@
 			"integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
 			"dev": true,
 			"requires": {
-				"acorn": "^6.0.1",
-				"acorn-walk": "^6.0.1"
+				"acorn": "6.0.4",
+				"acorn-walk": "6.1.0"
 			},
 			"dependencies": {
 				"acorn": {
@@ -89,10 +89,10 @@
 			"integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
 			"dev": true,
 			"requires": {
-				"co": "^4.6.0",
-				"fast-deep-equal": "^1.0.0",
-				"fast-json-stable-stringify": "^2.0.0",
-				"json-schema-traverse": "^0.3.0"
+				"co": "4.6.0",
+				"fast-deep-equal": "1.1.0",
+				"fast-json-stable-stringify": "2.0.0",
+				"json-schema-traverse": "0.3.1"
 			}
 		},
 		"ansi-escapes": {
@@ -118,7 +118,7 @@
 			"resolved": "https://registry.npmjs.org/antlr4-c3/-/antlr4-c3-1.1.8.tgz",
 			"integrity": "sha512-mxr73SsNZ8XFc6jzmJoNQvP2gqfwFGBwXVyFObnPjmU7UqsgACOLQ5V3Y2FYOuY87MDeOfEBOxZKvEG+yq8fwQ==",
 			"requires": {
-				"antlr4ts": "^0.4.1-alpha.0"
+				"antlr4ts": "0.4.1-alpha.0"
 			}
 		},
 		"antlr4ts": {
@@ -144,8 +144,8 @@
 			"integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
 			"dev": true,
 			"requires": {
-				"micromatch": "^3.1.4",
-				"normalize-path": "^2.1.1"
+				"micromatch": "3.1.10",
+				"normalize-path": "2.1.1"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -166,16 +166,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -184,7 +184,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -195,13 +195,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -210,7 +210,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -219,7 +219,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -228,7 +228,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -237,7 +237,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -248,7 +248,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -257,7 +257,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -268,9 +268,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -287,14 +287,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -303,7 +303,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -312,7 +312,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -323,10 +323,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -335,7 +335,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -346,7 +346,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -355,7 +355,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -364,9 +364,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -375,7 +375,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -384,7 +384,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -407,19 +407,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"normalize-path": {
@@ -428,7 +428,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"remove-trailing-separator": "1.1.0"
 					}
 				}
 			}
@@ -439,7 +439,7 @@
 			"integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
 			"dev": true,
 			"requires": {
-				"default-require-extensions": "^1.0.0"
+				"default-require-extensions": "1.0.0"
 			}
 		},
 		"argparse": {
@@ -448,7 +448,7 @@
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"dev": true,
 			"requires": {
-				"sprintf-js": "~1.0.2"
+				"sprintf-js": "1.0.3"
 			}
 		},
 		"arr-diff": {
@@ -457,7 +457,7 @@
 			"integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
 			"dev": true,
 			"requires": {
-				"arr-flatten": "^1.0.1"
+				"arr-flatten": "1.1.0"
 			}
 		},
 		"arr-flatten": {
@@ -514,7 +514,7 @@
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": "~2.1.0"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"assert-plus": {
@@ -540,7 +540,7 @@
 			"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 			"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 			"requires": {
-				"lodash": "^4.17.10"
+				"lodash": "4.17.11"
 			}
 		},
 		"async-limiter": {
@@ -579,9 +579,9 @@
 			"integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
+				"chalk": "1.1.3",
+				"esutils": "2.0.2",
+				"js-tokens": "3.0.2"
 			},
 			"dependencies": {
 				"chalk": {
@@ -590,11 +590,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -603,7 +603,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				}
 			}
@@ -614,25 +614,25 @@
 			"integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-generator": "^6.26.0",
-				"babel-helpers": "^6.24.1",
-				"babel-messages": "^6.23.0",
-				"babel-register": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"babel-template": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"convert-source-map": "^1.5.1",
-				"debug": "^2.6.9",
-				"json5": "^0.5.1",
-				"lodash": "^4.17.4",
-				"minimatch": "^3.0.4",
-				"path-is-absolute": "^1.0.1",
-				"private": "^0.1.8",
-				"slash": "^1.0.0",
-				"source-map": "^0.5.7"
+				"babel-code-frame": "6.26.0",
+				"babel-generator": "6.26.1",
+				"babel-helpers": "6.24.1",
+				"babel-messages": "6.23.0",
+				"babel-register": "6.26.0",
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"convert-source-map": "1.6.0",
+				"debug": "2.6.9",
+				"json5": "0.5.1",
+				"lodash": "4.17.11",
+				"minimatch": "3.0.4",
+				"path-is-absolute": "1.0.1",
+				"private": "0.1.8",
+				"slash": "1.0.0",
+				"source-map": "0.5.7"
 			}
 		},
 		"babel-generator": {
@@ -641,14 +641,14 @@
 			"integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
 			"dev": true,
 			"requires": {
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"detect-indent": "^4.0.0",
-				"jsesc": "^1.3.0",
-				"lodash": "^4.17.4",
-				"source-map": "^0.5.7",
-				"trim-right": "^1.0.1"
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"detect-indent": "4.0.0",
+				"jsesc": "1.3.0",
+				"lodash": "4.17.11",
+				"source-map": "0.5.7",
+				"trim-right": "1.0.1"
 			}
 		},
 		"babel-helpers": {
@@ -657,8 +657,8 @@
 			"integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0",
-				"babel-template": "^6.24.1"
+				"babel-runtime": "6.26.0",
+				"babel-template": "6.26.0"
 			}
 		},
 		"babel-jest": {
@@ -667,8 +667,8 @@
 			"integrity": "sha512-lqKGG6LYXYu+DQh/slrQ8nxXQkEkhugdXsU6St7GmhVS7Ilc/22ArwqXNJrf0QaOBjZB0360qZMwXqDYQHXaew==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-istanbul": "^4.1.6",
-				"babel-preset-jest": "^23.2.0"
+				"babel-plugin-istanbul": "4.1.6",
+				"babel-preset-jest": "23.2.0"
 			}
 		},
 		"babel-messages": {
@@ -677,7 +677,7 @@
 			"integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.22.0"
+				"babel-runtime": "6.26.0"
 			}
 		},
 		"babel-plugin-istanbul": {
@@ -686,10 +686,10 @@
 			"integrity": "sha512-PWP9FQ1AhZhS01T/4qLSKoHGY/xvkZdVBGlKM/HuxxS3+sC66HhTNR7+MpbO/so/cz/wY94MeSWJuP1hXIPfwQ==",
 			"dev": true,
 			"requires": {
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0",
-				"find-up": "^2.1.0",
-				"istanbul-lib-instrument": "^1.10.1",
-				"test-exclude": "^4.2.1"
+				"babel-plugin-syntax-object-rest-spread": "6.13.0",
+				"find-up": "2.1.0",
+				"istanbul-lib-instrument": "1.10.2",
+				"test-exclude": "4.2.3"
 			}
 		},
 		"babel-plugin-jest-hoist": {
@@ -710,8 +710,8 @@
 			"integrity": "sha1-jsegOhOPABoaj7HoETZSvxpV2kY=",
 			"dev": true,
 			"requires": {
-				"babel-plugin-jest-hoist": "^23.2.0",
-				"babel-plugin-syntax-object-rest-spread": "^6.13.0"
+				"babel-plugin-jest-hoist": "23.2.0",
+				"babel-plugin-syntax-object-rest-spread": "6.13.0"
 			}
 		},
 		"babel-register": {
@@ -720,13 +720,13 @@
 			"integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.26.0",
-				"babel-runtime": "^6.26.0",
-				"core-js": "^2.5.0",
-				"home-or-tmp": "^2.0.0",
-				"lodash": "^4.17.4",
-				"mkdirp": "^0.5.1",
-				"source-map-support": "^0.4.15"
+				"babel-core": "6.26.3",
+				"babel-runtime": "6.26.0",
+				"core-js": "2.5.7",
+				"home-or-tmp": "2.0.0",
+				"lodash": "4.17.11",
+				"mkdirp": "0.5.1",
+				"source-map-support": "0.4.18"
 			}
 		},
 		"babel-runtime": {
@@ -735,8 +735,8 @@
 			"integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
 			"dev": true,
 			"requires": {
-				"core-js": "^2.4.0",
-				"regenerator-runtime": "^0.11.0"
+				"core-js": "2.5.7",
+				"regenerator-runtime": "0.11.1"
 			}
 		},
 		"babel-template": {
@@ -745,11 +745,11 @@
 			"integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"babel-traverse": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"lodash": "^4.17.4"
+				"babel-runtime": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-traverse": {
@@ -758,15 +758,15 @@
 			"integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"babel-code-frame": "6.26.0",
+				"babel-messages": "6.23.0",
+				"babel-runtime": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"debug": "2.6.9",
+				"globals": "9.18.0",
+				"invariant": "2.2.4",
+				"lodash": "4.17.11"
 			}
 		},
 		"babel-types": {
@@ -775,10 +775,10 @@
 			"integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
 			"dev": true,
 			"requires": {
-				"babel-runtime": "^6.26.0",
-				"esutils": "^2.0.2",
-				"lodash": "^4.17.4",
-				"to-fast-properties": "^1.0.3"
+				"babel-runtime": "6.26.0",
+				"esutils": "2.0.2",
+				"lodash": "4.17.11",
+				"to-fast-properties": "1.0.3"
 			}
 		},
 		"babylon": {
@@ -799,13 +799,13 @@
 			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
 			"dev": true,
 			"requires": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
+				"cache-base": "1.0.1",
+				"class-utils": "0.3.6",
+				"component-emitter": "1.2.1",
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"mixin-deep": "1.3.1",
+				"pascalcase": "0.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -814,7 +814,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -823,7 +823,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -832,7 +832,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -841,9 +841,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -866,7 +866,7 @@
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
 			"dev": true,
 			"requires": {
-				"tweetnacl": "^0.14.3"
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"brace-expansion": {
@@ -875,7 +875,7 @@
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"requires": {
-				"balanced-match": "^1.0.0",
+				"balanced-match": "1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -885,9 +885,9 @@
 			"integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
 			"dev": true,
 			"requires": {
-				"expand-range": "^1.8.1",
-				"preserve": "^0.2.0",
-				"repeat-element": "^1.1.2"
+				"expand-range": "1.8.2",
+				"preserve": "0.2.0",
+				"repeat-element": "1.1.3"
 			}
 		},
 		"browser-process-hrtime": {
@@ -911,7 +911,7 @@
 			"integrity": "sha512-uFLE0LFMxrH8Z5Hd9QgivvRbrl/NFkOTHzGhlqQxsnmx5JBLrp4bc249afLL+GccyY/8hkcGi2LpVaOzaEY0nQ==",
 			"dev": true,
 			"requires": {
-				"fast-json-stable-stringify": "^2.0.0"
+				"fast-json-stable-stringify": "2.0.0"
 			}
 		},
 		"bser": {
@@ -920,7 +920,7 @@
 			"integrity": "sha1-mseNPtXZFYBP2HrLFYvHlxR6Fxk=",
 			"dev": true,
 			"requires": {
-				"node-int64": "^0.4.0"
+				"node-int64": "0.4.0"
 			}
 		},
 		"buffer-from": {
@@ -941,15 +941,15 @@
 			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
 			"dev": true,
 			"requires": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
+				"collection-visit": "1.0.0",
+				"component-emitter": "1.2.1",
+				"get-value": "2.0.6",
+				"has-value": "1.0.0",
+				"isobject": "3.0.1",
+				"set-value": "2.0.0",
+				"to-object-path": "0.3.0",
+				"union-value": "1.0.0",
+				"unset-value": "1.0.0"
 			},
 			"dependencies": {
 				"isobject": {
@@ -978,7 +978,7 @@
 			"integrity": "sha1-HF/MSJ/QqwDU8ax64QcuMXP7q28=",
 			"dev": true,
 			"requires": {
-				"rsvp": "^3.3.3"
+				"rsvp": "3.6.2"
 			}
 		},
 		"caseless": {
@@ -993,9 +993,9 @@
 			"integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
+				"ansi-styles": "3.2.1",
+				"escape-string-regexp": "1.0.5",
+				"supports-color": "5.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -1004,7 +1004,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"has-flag": {
@@ -1019,7 +1019,7 @@
 					"integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
 					"dev": true,
 					"requires": {
-						"has-flag": "^3.0.0"
+						"has-flag": "3.0.0"
 					}
 				}
 			}
@@ -1036,10 +1036,10 @@
 			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
+				"arr-union": "3.1.0",
+				"define-property": "0.2.5",
+				"isobject": "3.0.1",
+				"static-extend": "0.1.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -1048,7 +1048,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"isobject": {
@@ -1065,7 +1065,7 @@
 			"integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
 			"dev": true,
 			"requires": {
-				"restore-cursor": "^1.0.1"
+				"restore-cursor": "1.0.1"
 			}
 		},
 		"cli-truncate": {
@@ -1075,7 +1075,7 @@
 			"dev": true,
 			"requires": {
 				"slice-ansi": "0.0.4",
-				"string-width": "^1.0.1"
+				"string-width": "1.0.2"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -1084,7 +1084,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -1093,9 +1093,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"strip-ansi": {
@@ -1104,7 +1104,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				}
 			}
@@ -1115,9 +1115,9 @@
 			"integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
 			"dev": true,
 			"requires": {
-				"string-width": "^2.1.1",
-				"strip-ansi": "^4.0.0",
-				"wrap-ansi": "^2.0.0"
+				"string-width": "2.1.1",
+				"strip-ansi": "4.0.0",
+				"wrap-ansi": "2.1.0"
 			}
 		},
 		"co": {
@@ -1138,8 +1138,8 @@
 			"integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
 			"dev": true,
 			"requires": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
+				"map-visit": "1.0.0",
+				"object-visit": "1.0.1"
 			}
 		},
 		"color": {
@@ -1147,8 +1147,8 @@
 			"resolved": "https://registry.npmjs.org/color/-/color-3.0.0.tgz",
 			"integrity": "sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==",
 			"requires": {
-				"color-convert": "^1.9.1",
-				"color-string": "^1.5.2"
+				"color-convert": "1.9.1",
+				"color-string": "1.5.3"
 			}
 		},
 		"color-convert": {
@@ -1156,7 +1156,7 @@
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
 			"integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
 			"requires": {
-				"color-name": "^1.1.1"
+				"color-name": "1.1.3"
 			}
 		},
 		"color-name": {
@@ -1169,8 +1169,8 @@
 			"resolved": "https://registry.npmjs.org/color-string/-/color-string-1.5.3.tgz",
 			"integrity": "sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==",
 			"requires": {
-				"color-name": "^1.0.0",
-				"simple-swizzle": "^0.2.2"
+				"color-name": "1.1.3",
+				"simple-swizzle": "0.2.2"
 			}
 		},
 		"colornames": {
@@ -1188,8 +1188,8 @@
 			"resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.1.tgz",
 			"integrity": "sha512-pI3btWyiuz7Ken0BWh9Elzsmv2bM9AhA7psXib4anUXy/orfZ/E0MbQwhSOG/9L8hLlalqrU0UhOuqxW1YjmVw==",
 			"requires": {
-				"color": "3.0.x",
-				"text-hex": "1.0.x"
+				"color": "3.0.0",
+				"text-hex": "1.0.0"
 			}
 		},
 		"combined-stream": {
@@ -1198,7 +1198,7 @@
 			"integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
 			"dev": true,
 			"requires": {
-				"delayed-stream": "~1.0.0"
+				"delayed-stream": "1.0.0"
 			}
 		},
 		"commander": {
@@ -1225,7 +1225,7 @@
 			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "~5.1.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"copy-descriptor": {
@@ -1251,9 +1251,9 @@
 			"integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
 			"dev": true,
 			"requires": {
-				"is-directory": "^0.3.1",
-				"js-yaml": "^3.9.0",
-				"parse-json": "^4.0.0"
+				"is-directory": "0.3.1",
+				"js-yaml": "3.12.0",
+				"parse-json": "4.0.0"
 			}
 		},
 		"cross-spawn": {
@@ -1262,9 +1262,9 @@
 			"integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
 			"dev": true,
 			"requires": {
-				"lru-cache": "^4.0.1",
-				"shebang-command": "^1.2.0",
-				"which": "^1.2.9"
+				"lru-cache": "4.1.3",
+				"shebang-command": "1.2.0",
+				"which": "1.3.1"
 			}
 		},
 		"cssom": {
@@ -1279,7 +1279,7 @@
 			"integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
 			"dev": true,
 			"requires": {
-				"cssom": "0.3.x"
+				"cssom": "0.3.4"
 			}
 		},
 		"dashdash": {
@@ -1288,7 +1288,7 @@
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"data-urls": {
@@ -1297,9 +1297,9 @@
 			"integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"whatwg-mimetype": "^2.2.0",
-				"whatwg-url": "^7.0.0"
+				"abab": "2.0.0",
+				"whatwg-mimetype": "2.2.0",
+				"whatwg-url": "7.0.0"
 			},
 			"dependencies": {
 				"whatwg-url": {
@@ -1308,9 +1308,9 @@
 					"integrity": "sha512-37GeVSIJ3kn1JgKyjiYNmSLP1yzbpb29jdmwBSgkD9h40/hyrR/OifpVUndji3tmwGgD8qpw7iQu3RSbCrBpsQ==",
 					"dev": true,
 					"requires": {
-						"lodash.sortby": "^4.7.0",
-						"tr46": "^1.0.1",
-						"webidl-conversions": "^4.0.2"
+						"lodash.sortby": "4.7.0",
+						"tr46": "1.0.1",
+						"webidl-conversions": "4.0.2"
 					}
 				}
 			}
@@ -1360,7 +1360,7 @@
 			"integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
 			"dev": true,
 			"requires": {
-				"strip-bom": "^2.0.0"
+				"strip-bom": "2.0.0"
 			},
 			"dependencies": {
 				"strip-bom": {
@@ -1369,7 +1369,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -1380,8 +1380,8 @@
 			"integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
 			"dev": true,
 			"requires": {
-				"foreach": "^2.0.5",
-				"object-keys": "^1.0.8"
+				"foreach": "2.0.5",
+				"object-keys": "1.0.11"
 			}
 		},
 		"define-property": {
@@ -1390,8 +1390,8 @@
 			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
 			"dev": true,
 			"requires": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
+				"is-descriptor": "1.0.2",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"is-accessor-descriptor": {
@@ -1400,7 +1400,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -1409,7 +1409,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -1418,9 +1418,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -1449,7 +1449,7 @@
 			"integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
 			"dev": true,
 			"requires": {
-				"repeating": "^2.0.0"
+				"repeating": "2.0.1"
 			}
 		},
 		"detect-newline": {
@@ -1463,9 +1463,9 @@
 			"resolved": "https://registry.npmjs.org/diagnostics/-/diagnostics-1.1.1.tgz",
 			"integrity": "sha512-8wn1PmdunLJ9Tqbx+Fx/ZEuHfJf4NKSN2ZBj7SJC/OWRWha843+WsTjqMe1B5E3p28jqBlp+mJ2fPVxPyNgYKQ==",
 			"requires": {
-				"colorspace": "1.1.x",
-				"enabled": "1.0.x",
-				"kuler": "1.0.x"
+				"colorspace": "1.1.1",
+				"enabled": "1.0.2",
+				"kuler": "1.0.1"
 			}
 		},
 		"diff": {
@@ -1480,7 +1480,7 @@
 			"integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
 			"dev": true,
 			"requires": {
-				"webidl-conversions": "^4.0.2"
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"duplexer": {
@@ -1495,8 +1495,8 @@
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
 			"dev": true,
 			"requires": {
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.1.0"
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"elegant-spinner": {
@@ -1510,7 +1510,7 @@
 			"resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
 			"integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
 			"requires": {
-				"env-variable": "0.0.x"
+				"env-variable": "0.0.5"
 			}
 		},
 		"env-variable": {
@@ -1524,7 +1524,7 @@
 			"integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
 			"dev": true,
 			"requires": {
-				"is-arrayish": "^0.2.1"
+				"is-arrayish": "0.2.1"
 			}
 		},
 		"es-abstract": {
@@ -1533,11 +1533,11 @@
 			"integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
 			"dev": true,
 			"requires": {
-				"es-to-primitive": "^1.1.1",
-				"function-bind": "^1.1.1",
-				"has": "^1.0.1",
-				"is-callable": "^1.1.3",
-				"is-regex": "^1.0.4"
+				"es-to-primitive": "1.1.1",
+				"function-bind": "1.1.1",
+				"has": "1.0.1",
+				"is-callable": "1.1.3",
+				"is-regex": "1.0.4"
 			}
 		},
 		"es-to-primitive": {
@@ -1546,9 +1546,9 @@
 			"integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
 			"dev": true,
 			"requires": {
-				"is-callable": "^1.1.1",
-				"is-date-object": "^1.0.1",
-				"is-symbol": "^1.0.1"
+				"is-callable": "1.1.3",
+				"is-date-object": "1.0.1",
+				"is-symbol": "1.0.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -1563,11 +1563,11 @@
 			"integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
 			"dev": true,
 			"requires": {
-				"esprima": "^3.1.3",
-				"estraverse": "^4.2.0",
-				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"esprima": "3.1.3",
+				"estraverse": "4.2.0",
+				"esutils": "2.0.2",
+				"optionator": "0.8.2",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"esprima": {
@@ -1609,13 +1609,13 @@
 			"integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
 			"dev": true,
 			"requires": {
-				"duplexer": "~0.1.1",
-				"from": "~0",
-				"map-stream": "~0.1.0",
+				"duplexer": "0.1.1",
+				"from": "0.1.7",
+				"map-stream": "0.1.0",
 				"pause-stream": "0.0.11",
-				"split": "0.3",
-				"stream-combiner": "~0.0.4",
-				"through": "~2.3.1"
+				"split": "0.3.3",
+				"stream-combiner": "0.0.4",
+				"through": "2.3.8"
 			}
 		},
 		"exec-sh": {
@@ -1624,7 +1624,7 @@
 			"integrity": "sha512-FIUCJz1RbuS0FKTdaAafAByGS0CPvU3R0MeHxgtl+djzCc//F8HakL8GzmVNZanasTbTAY/3DRFA0KpVqj/eAw==",
 			"dev": true,
 			"requires": {
-				"merge": "^1.2.0"
+				"merge": "1.2.1"
 			}
 		},
 		"execa": {
@@ -1633,13 +1633,13 @@
 			"integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
 			"dev": true,
 			"requires": {
-				"cross-spawn": "^5.0.1",
-				"get-stream": "^3.0.0",
-				"is-stream": "^1.1.0",
-				"npm-run-path": "^2.0.0",
-				"p-finally": "^1.0.0",
-				"signal-exit": "^3.0.0",
-				"strip-eof": "^1.0.0"
+				"cross-spawn": "5.1.0",
+				"get-stream": "3.0.0",
+				"is-stream": "1.1.0",
+				"npm-run-path": "2.0.2",
+				"p-finally": "1.0.0",
+				"signal-exit": "3.0.2",
+				"strip-eof": "1.0.0"
 			}
 		},
 		"exit": {
@@ -1660,7 +1660,7 @@
 			"integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
 			"dev": true,
 			"requires": {
-				"is-posix-bracket": "^0.1.0"
+				"is-posix-bracket": "0.1.1"
 			}
 		},
 		"expand-range": {
@@ -1669,7 +1669,7 @@
 			"integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
 			"dev": true,
 			"requires": {
-				"fill-range": "^2.1.0"
+				"fill-range": "2.2.4"
 			}
 		},
 		"expect": {
@@ -1678,12 +1678,12 @@
 			"integrity": "sha512-dgSoOHgmtn/aDGRVFWclQyPDKl2CQRq0hmIEoUAuQs/2rn2NcvCWcSCovm6BLeuB/7EZuLGu2QfnR+qRt5OM4w==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"jest-diff": "^23.6.0",
-				"jest-get-type": "^22.1.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0"
+				"ansi-styles": "3.2.1",
+				"jest-diff": "23.6.0",
+				"jest-get-type": "22.4.3",
+				"jest-matcher-utils": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-regex-util": "23.3.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -1692,7 +1692,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -1709,8 +1709,8 @@
 			"integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
 			"dev": true,
 			"requires": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
+				"assign-symbols": "1.0.0",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -1719,7 +1719,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -1730,7 +1730,7 @@
 			"integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"extsprintf": {
@@ -1768,7 +1768,7 @@
 			"integrity": "sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=",
 			"dev": true,
 			"requires": {
-				"bser": "^2.0.0"
+				"bser": "2.0.0"
 			}
 		},
 		"fecha": {
@@ -1782,8 +1782,8 @@
 			"integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
 			"dev": true,
 			"requires": {
-				"escape-string-regexp": "^1.0.5",
-				"object-assign": "^4.1.0"
+				"escape-string-regexp": "1.0.5",
+				"object-assign": "4.1.1"
 			}
 		},
 		"filename-regex": {
@@ -1798,8 +1798,8 @@
 			"integrity": "sha1-jnVIqW08wjJ+5eZ0FocjozO7oqA=",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.3",
-				"minimatch": "^3.0.3"
+				"glob": "7.1.3",
+				"minimatch": "3.0.4"
 			}
 		},
 		"fill-range": {
@@ -1808,11 +1808,11 @@
 			"integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
 			"dev": true,
 			"requires": {
-				"is-number": "^2.1.0",
-				"isobject": "^2.0.0",
-				"randomatic": "^3.0.0",
-				"repeat-element": "^1.1.2",
-				"repeat-string": "^1.5.2"
+				"is-number": "2.1.0",
+				"isobject": "2.1.0",
+				"randomatic": "3.1.1",
+				"repeat-element": "1.1.3",
+				"repeat-string": "1.6.1"
 			}
 		},
 		"find-parent-dir": {
@@ -1827,7 +1827,7 @@
 			"integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
 			"dev": true,
 			"requires": {
-				"locate-path": "^2.0.0"
+				"locate-path": "2.0.0"
 			}
 		},
 		"for-in": {
@@ -1842,7 +1842,7 @@
 			"integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.1"
+				"for-in": "1.0.2"
 			}
 		},
 		"foreach": {
@@ -1863,9 +1863,9 @@
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
 			"dev": true,
 			"requires": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.6",
-				"mime-types": "^2.1.12"
+				"asynckit": "0.4.0",
+				"combined-stream": "1.0.7",
+				"mime-types": "2.1.21"
 			}
 		},
 		"fragment-cache": {
@@ -1874,7 +1874,7 @@
 			"integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
 			"dev": true,
 			"requires": {
-				"map-cache": "^0.2.2"
+				"map-cache": "0.2.2"
 			}
 		},
 		"from": {
@@ -1896,8 +1896,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"nan": "^2.9.2",
-				"node-pre-gyp": "^0.10.0"
+				"nan": "2.11.1",
+				"node-pre-gyp": "0.10.0"
 			},
 			"dependencies": {
 				"abbrev": {
@@ -1923,8 +1923,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"delegates": "^1.0.0",
-						"readable-stream": "^2.0.6"
+						"delegates": "1.0.0",
+						"readable-stream": "2.3.6"
 					}
 				},
 				"balanced-match": {
@@ -1937,7 +1937,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"balanced-match": "^1.0.0",
+						"balanced-match": "1.0.0",
 						"concat-map": "0.0.1"
 					}
 				},
@@ -2001,7 +2001,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"fs.realpath": {
@@ -2016,14 +2016,14 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"aproba": "^1.0.3",
-						"console-control-strings": "^1.0.0",
-						"has-unicode": "^2.0.0",
-						"object-assign": "^4.1.0",
-						"signal-exit": "^3.0.0",
-						"string-width": "^1.0.1",
-						"strip-ansi": "^3.0.1",
-						"wide-align": "^1.1.0"
+						"aproba": "1.2.0",
+						"console-control-strings": "1.1.0",
+						"has-unicode": "2.0.1",
+						"object-assign": "4.1.1",
+						"signal-exit": "3.0.2",
+						"string-width": "1.0.2",
+						"strip-ansi": "3.0.1",
+						"wide-align": "1.1.2"
 					}
 				},
 				"glob": {
@@ -2032,12 +2032,12 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
+						"fs.realpath": "1.0.0",
+						"inflight": "1.0.6",
+						"inherits": "2.0.3",
+						"minimatch": "3.0.4",
+						"once": "1.4.0",
+						"path-is-absolute": "1.0.1"
 					}
 				},
 				"has-unicode": {
@@ -2052,7 +2052,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safer-buffer": "^2.1.0"
+						"safer-buffer": "2.1.2"
 					}
 				},
 				"ignore-walk": {
@@ -2061,7 +2061,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minimatch": "^3.0.4"
+						"minimatch": "3.0.4"
 					}
 				},
 				"inflight": {
@@ -2070,8 +2070,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"once": "^1.3.0",
-						"wrappy": "1"
+						"once": "1.4.0",
+						"wrappy": "1.0.2"
 					}
 				},
 				"inherits": {
@@ -2090,7 +2090,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"isarray": {
@@ -2104,7 +2104,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^1.1.7"
+						"brace-expansion": "1.1.11"
 					}
 				},
 				"minimist": {
@@ -2117,8 +2117,8 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.0"
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"minizlib": {
@@ -2127,7 +2127,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"minipass": "^2.2.1"
+						"minipass": "2.2.4"
 					}
 				},
 				"mkdirp": {
@@ -2150,9 +2150,9 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"debug": "^2.1.2",
-						"iconv-lite": "^0.4.4",
-						"sax": "^1.2.4"
+						"debug": "2.6.9",
+						"iconv-lite": "0.4.21",
+						"sax": "1.2.4"
 					}
 				},
 				"node-pre-gyp": {
@@ -2161,16 +2161,16 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"detect-libc": "^1.0.2",
-						"mkdirp": "^0.5.1",
-						"needle": "^2.2.0",
-						"nopt": "^4.0.1",
-						"npm-packlist": "^1.1.6",
-						"npmlog": "^4.0.2",
-						"rc": "^1.1.7",
-						"rimraf": "^2.6.1",
-						"semver": "^5.3.0",
-						"tar": "^4"
+						"detect-libc": "1.0.3",
+						"mkdirp": "0.5.1",
+						"needle": "2.2.0",
+						"nopt": "4.0.1",
+						"npm-packlist": "1.1.10",
+						"npmlog": "4.1.2",
+						"rc": "1.2.7",
+						"rimraf": "2.6.2",
+						"semver": "5.5.0",
+						"tar": "4.4.1"
 					}
 				},
 				"nopt": {
@@ -2179,8 +2179,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"abbrev": "1",
-						"osenv": "^0.1.4"
+						"abbrev": "1.1.1",
+						"osenv": "0.1.5"
 					}
 				},
 				"npm-bundled": {
@@ -2195,8 +2195,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"ignore-walk": "^3.0.1",
-						"npm-bundled": "^1.0.1"
+						"ignore-walk": "3.0.1",
+						"npm-bundled": "1.0.3"
 					}
 				},
 				"npmlog": {
@@ -2205,10 +2205,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"are-we-there-yet": "~1.1.2",
-						"console-control-strings": "~1.1.0",
-						"gauge": "~2.7.3",
-						"set-blocking": "~2.0.0"
+						"are-we-there-yet": "1.1.4",
+						"console-control-strings": "1.1.0",
+						"gauge": "2.7.4",
+						"set-blocking": "2.0.0"
 					}
 				},
 				"number-is-nan": {
@@ -2227,7 +2227,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"wrappy": "1"
+						"wrappy": "1.0.2"
 					}
 				},
 				"os-homedir": {
@@ -2248,8 +2248,8 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.0"
+						"os-homedir": "1.0.2",
+						"os-tmpdir": "1.0.2"
 					}
 				},
 				"path-is-absolute": {
@@ -2270,10 +2270,10 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"deep-extend": "^0.5.1",
-						"ini": "~1.3.0",
-						"minimist": "^1.2.0",
-						"strip-json-comments": "~2.0.1"
+						"deep-extend": "0.5.1",
+						"ini": "1.3.5",
+						"minimist": "1.2.0",
+						"strip-json-comments": "2.0.1"
 					},
 					"dependencies": {
 						"minimist": {
@@ -2290,13 +2290,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"core-util-is": "~1.0.0",
-						"inherits": "~2.0.3",
-						"isarray": "~1.0.0",
-						"process-nextick-args": "~2.0.0",
-						"safe-buffer": "~5.1.1",
-						"string_decoder": "~1.1.1",
-						"util-deprecate": "~1.0.1"
+						"core-util-is": "1.0.2",
+						"inherits": "2.0.3",
+						"isarray": "1.0.0",
+						"process-nextick-args": "2.0.0",
+						"safe-buffer": "5.1.1",
+						"string_decoder": "1.1.1",
+						"util-deprecate": "1.0.2"
 					}
 				},
 				"rimraf": {
@@ -2305,7 +2305,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"glob": "^7.0.5"
+						"glob": "7.1.2"
 					}
 				},
 				"safe-buffer": {
@@ -2348,9 +2348,9 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"string_decoder": {
@@ -2359,7 +2359,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"safe-buffer": "~5.1.0"
+						"safe-buffer": "5.1.1"
 					}
 				},
 				"strip-ansi": {
@@ -2367,7 +2367,7 @@
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				},
 				"strip-json-comments": {
@@ -2382,13 +2382,13 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"chownr": "^1.0.1",
-						"fs-minipass": "^1.2.5",
-						"minipass": "^2.2.4",
-						"minizlib": "^1.1.0",
-						"mkdirp": "^0.5.0",
-						"safe-buffer": "^5.1.1",
-						"yallist": "^3.0.2"
+						"chownr": "1.0.1",
+						"fs-minipass": "1.2.5",
+						"minipass": "2.2.4",
+						"minizlib": "1.1.0",
+						"mkdirp": "0.5.1",
+						"safe-buffer": "5.1.1",
+						"yallist": "3.0.2"
 					}
 				},
 				"util-deprecate": {
@@ -2403,7 +2403,7 @@
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"string-width": "^1.0.2"
+						"string-width": "1.0.2"
 					}
 				},
 				"wrappy": {
@@ -2454,7 +2454,7 @@
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0"
+				"assert-plus": "1.0.0"
 			}
 		},
 		"glob": {
@@ -2463,12 +2463,12 @@
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"requires": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.0.4",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
+				"fs.realpath": "1.0.0",
+				"inflight": "1.0.6",
+				"inherits": "2.0.3",
+				"minimatch": "3.0.4",
+				"once": "1.4.0",
+				"path-is-absolute": "1.0.1"
 			}
 		},
 		"glob-base": {
@@ -2477,8 +2477,8 @@
 			"integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
 			"dev": true,
 			"requires": {
-				"glob-parent": "^2.0.0",
-				"is-glob": "^2.0.0"
+				"glob-parent": "2.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"glob-parent": {
@@ -2487,7 +2487,7 @@
 			"integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
 			"dev": true,
 			"requires": {
-				"is-glob": "^2.0.0"
+				"is-glob": "2.0.1"
 			}
 		},
 		"globals": {
@@ -2514,10 +2514,10 @@
 			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.5.0",
-				"optimist": "^0.6.1",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4"
+				"async": "2.6.1",
+				"optimist": "0.6.1",
+				"source-map": "0.6.1",
+				"uglify-js": "3.4.9"
 			},
 			"dependencies": {
 				"source-map": {
@@ -2540,8 +2540,8 @@
 			"integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
 			"dev": true,
 			"requires": {
-				"ajv": "^5.3.0",
-				"har-schema": "^2.0.0"
+				"ajv": "5.5.2",
+				"har-schema": "2.0.0"
 			}
 		},
 		"has": {
@@ -2550,7 +2550,7 @@
 			"integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
 			"dev": true,
 			"requires": {
-				"function-bind": "^1.0.2"
+				"function-bind": "1.1.1"
 			}
 		},
 		"has-ansi": {
@@ -2559,7 +2559,7 @@
 			"integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^2.0.0"
+				"ansi-regex": "2.1.1"
 			}
 		},
 		"has-flag": {
@@ -2574,9 +2574,9 @@
 			"integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
 			"dev": true,
 			"requires": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
+				"get-value": "2.0.6",
+				"has-values": "1.0.0",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -2593,8 +2593,8 @@
 			"integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
+				"is-number": "3.0.0",
+				"kind-of": "4.0.0"
 			},
 			"dependencies": {
 				"is-number": {
@@ -2603,7 +2603,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -2612,7 +2612,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -2623,7 +2623,7 @@
 					"integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
 					"dev": true,
 					"requires": {
-						"is-buffer": "^1.1.5"
+						"is-buffer": "1.1.6"
 					}
 				}
 			}
@@ -2634,8 +2634,8 @@
 			"integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
 			"dev": true,
 			"requires": {
-				"os-homedir": "^1.0.0",
-				"os-tmpdir": "^1.0.1"
+				"os-homedir": "1.0.2",
+				"os-tmpdir": "1.0.2"
 			}
 		},
 		"hosted-git-info": {
@@ -2650,7 +2650,7 @@
 			"integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
 			"dev": true,
 			"requires": {
-				"whatwg-encoding": "^1.0.1"
+				"whatwg-encoding": "1.0.5"
 			}
 		},
 		"http-signature": {
@@ -2659,9 +2659,9 @@
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
-				"jsprim": "^1.2.2",
-				"sshpk": "^1.7.0"
+				"assert-plus": "1.0.0",
+				"jsprim": "1.4.1",
+				"sshpk": "1.15.2"
 			}
 		},
 		"husky": {
@@ -2670,9 +2670,9 @@
 			"integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
 			"dev": true,
 			"requires": {
-				"is-ci": "^1.0.10",
-				"normalize-path": "^1.0.0",
-				"strip-indent": "^2.0.0"
+				"is-ci": "1.1.0",
+				"normalize-path": "1.0.0",
+				"strip-indent": "2.0.0"
 			}
 		},
 		"iconv-lite": {
@@ -2681,7 +2681,7 @@
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"requires": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": "2.1.2"
 			}
 		},
 		"import-local": {
@@ -2690,8 +2690,8 @@
 			"integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
 			"dev": true,
 			"requires": {
-				"pkg-dir": "^2.0.0",
-				"resolve-cwd": "^2.0.0"
+				"pkg-dir": "2.0.0",
+				"resolve-cwd": "2.0.0"
 			}
 		},
 		"imurmurhash": {
@@ -2712,8 +2712,8 @@
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
+				"once": "1.4.0",
+				"wrappy": "1.0.2"
 			}
 		},
 		"inherits": {
@@ -2727,7 +2727,7 @@
 			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
 			"dev": true,
 			"requires": {
-				"loose-envify": "^1.0.0"
+				"loose-envify": "1.4.0"
 			}
 		},
 		"invert-kv": {
@@ -2742,7 +2742,7 @@
 			"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-arrayish": {
@@ -2763,7 +2763,7 @@
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"dev": true,
 			"requires": {
-				"builtin-modules": "^1.0.0"
+				"builtin-modules": "1.1.1"
 			}
 		},
 		"is-callable": {
@@ -2778,7 +2778,7 @@
 			"integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
 			"dev": true,
 			"requires": {
-				"ci-info": "^1.0.0"
+				"ci-info": "1.1.3"
 			}
 		},
 		"is-data-descriptor": {
@@ -2787,7 +2787,7 @@
 			"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-date-object": {
@@ -2802,9 +2802,9 @@
 			"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 			"dev": true,
 			"requires": {
-				"is-accessor-descriptor": "^0.1.6",
-				"is-data-descriptor": "^0.1.4",
-				"kind-of": "^5.0.0"
+				"is-accessor-descriptor": "0.1.6",
+				"is-data-descriptor": "0.1.4",
+				"kind-of": "5.1.0"
 			},
 			"dependencies": {
 				"kind-of": {
@@ -2833,7 +2833,7 @@
 			"integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
 			"dev": true,
 			"requires": {
-				"is-primitive": "^2.0.0"
+				"is-primitive": "2.0.0"
 			}
 		},
 		"is-extendable": {
@@ -2854,7 +2854,7 @@
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"dev": true,
 			"requires": {
-				"number-is-nan": "^1.0.0"
+				"number-is-nan": "1.0.1"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -2875,7 +2875,7 @@
 			"integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
 			"dev": true,
 			"requires": {
-				"is-extglob": "^1.0.0"
+				"is-extglob": "1.0.0"
 			}
 		},
 		"is-number": {
@@ -2884,7 +2884,7 @@
 			"integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"is-obj": {
@@ -2899,7 +2899,7 @@
 			"integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
 			"dev": true,
 			"requires": {
-				"symbol-observable": "^1.1.0"
+				"symbol-observable": "1.2.0"
 			}
 		},
 		"is-plain-object": {
@@ -2908,7 +2908,7 @@
 			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -2943,7 +2943,7 @@
 			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.1"
+				"has": "1.0.1"
 			}
 		},
 		"is-regexp": {
@@ -3013,17 +3013,17 @@
 			"integrity": "sha512-4/ApBnMVeEPG3EkSzcw25wDe4N66wxwn+KKn6b47vyek8Xb3NBAcg4xfuQbS7BqcZuTX4wxfD5lVagdggR3gyA==",
 			"dev": true,
 			"requires": {
-				"async": "^2.1.4",
-				"fileset": "^2.0.2",
-				"istanbul-lib-coverage": "^1.2.1",
-				"istanbul-lib-hook": "^1.2.2",
-				"istanbul-lib-instrument": "^1.10.2",
-				"istanbul-lib-report": "^1.1.5",
-				"istanbul-lib-source-maps": "^1.2.6",
-				"istanbul-reports": "^1.5.1",
-				"js-yaml": "^3.7.0",
-				"mkdirp": "^0.5.1",
-				"once": "^1.4.0"
+				"async": "2.6.1",
+				"fileset": "2.0.3",
+				"istanbul-lib-coverage": "1.2.1",
+				"istanbul-lib-hook": "1.2.2",
+				"istanbul-lib-instrument": "1.10.2",
+				"istanbul-lib-report": "1.1.5",
+				"istanbul-lib-source-maps": "1.2.6",
+				"istanbul-reports": "1.5.1",
+				"js-yaml": "3.12.0",
+				"mkdirp": "0.5.1",
+				"once": "1.4.0"
 			}
 		},
 		"istanbul-lib-coverage": {
@@ -3038,7 +3038,7 @@
 			"integrity": "sha512-/Jmq7Y1VeHnZEQ3TL10VHyb564mn6VrQXHchON9Jf/AEcmQ3ZIiyD1BVzNOKTZf/G3gE+kiGK6SmpF9y3qGPLw==",
 			"dev": true,
 			"requires": {
-				"append-transform": "^0.4.0"
+				"append-transform": "0.4.0"
 			}
 		},
 		"istanbul-lib-instrument": {
@@ -3047,13 +3047,13 @@
 			"integrity": "sha512-aWHxfxDqvh/ZlxR8BBaEPVSWDPUkGD63VjGQn3jcw8jCp7sHEMKcrj4xfJn/ABzdMEHiQNyvDQhqm5o8+SQg7A==",
 			"dev": true,
 			"requires": {
-				"babel-generator": "^6.18.0",
-				"babel-template": "^6.16.0",
-				"babel-traverse": "^6.18.0",
-				"babel-types": "^6.18.0",
-				"babylon": "^6.18.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"semver": "^5.3.0"
+				"babel-generator": "6.26.1",
+				"babel-template": "6.26.0",
+				"babel-traverse": "6.26.0",
+				"babel-types": "6.26.0",
+				"babylon": "6.18.0",
+				"istanbul-lib-coverage": "1.2.1",
+				"semver": "5.5.0"
 			}
 		},
 		"istanbul-lib-report": {
@@ -3062,10 +3062,10 @@
 			"integrity": "sha512-UsYfRMoi6QO/doUshYNqcKJqVmFe9w51GZz8BS3WB0lYxAllQYklka2wP9+dGZeHYaWIdcXUx8JGdbqaoXRXzw==",
 			"dev": true,
 			"requires": {
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"path-parse": "^1.0.5",
-				"supports-color": "^3.1.2"
+				"istanbul-lib-coverage": "1.2.1",
+				"mkdirp": "0.5.1",
+				"path-parse": "1.0.6",
+				"supports-color": "3.2.3"
 			},
 			"dependencies": {
 				"supports-color": {
@@ -3074,7 +3074,7 @@
 					"integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
 					"dev": true,
 					"requires": {
-						"has-flag": "^1.0.0"
+						"has-flag": "1.0.0"
 					}
 				}
 			}
@@ -3085,11 +3085,11 @@
 			"integrity": "sha512-TtbsY5GIHgbMsMiRw35YBHGpZ1DVFEO19vxxeiDMYaeOFOCzfnYVxvl6pOUIZR4dtPhAGpSMup8OyF8ubsaqEg==",
 			"dev": true,
 			"requires": {
-				"debug": "^3.1.0",
-				"istanbul-lib-coverage": "^1.2.1",
-				"mkdirp": "^0.5.1",
-				"rimraf": "^2.6.1",
-				"source-map": "^0.5.3"
+				"debug": "3.2.6",
+				"istanbul-lib-coverage": "1.2.1",
+				"mkdirp": "0.5.1",
+				"rimraf": "2.6.2",
+				"source-map": "0.5.7"
 			},
 			"dependencies": {
 				"debug": {
@@ -3098,7 +3098,7 @@
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.1"
 					}
 				},
 				"ms": {
@@ -3115,7 +3115,7 @@
 			"integrity": "sha512-+cfoZ0UXzWjhAdzosCPP3AN8vvef8XDkWtTfgaN+7L3YTpNYITnCaEkceo5SEYy644VkHka/P1FvkWvrG/rrJw==",
 			"dev": true,
 			"requires": {
-				"handlebars": "^4.0.3"
+				"handlebars": "4.0.12"
 			}
 		},
 		"jest": {
@@ -3124,8 +3124,8 @@
 			"integrity": "sha512-lWzcd+HSiqeuxyhG+EnZds6iO3Y3ZEnMrfZq/OTGvF/C+Z4fPMCdhWTGSAiO2Oym9rbEXfwddHhh6jqrTF3+Lw==",
 			"dev": true,
 			"requires": {
-				"import-local": "^1.0.0",
-				"jest-cli": "^23.6.0"
+				"import-local": "1.0.0",
+				"jest-cli": "23.6.0"
 			},
 			"dependencies": {
 				"jest-cli": {
@@ -3134,42 +3134,42 @@
 					"integrity": "sha512-hgeD1zRUp1E1zsiyOXjEn4LzRLWdJBV//ukAHGlx6s5mfCNJTbhbHjgxnDUXA8fsKWN/HqFFF6X5XcCwC/IvYQ==",
 					"dev": true,
 					"requires": {
-						"ansi-escapes": "^3.0.0",
-						"chalk": "^2.0.1",
-						"exit": "^0.1.2",
-						"glob": "^7.1.2",
-						"graceful-fs": "^4.1.11",
-						"import-local": "^1.0.0",
-						"is-ci": "^1.0.10",
-						"istanbul-api": "^1.3.1",
-						"istanbul-lib-coverage": "^1.2.0",
-						"istanbul-lib-instrument": "^1.10.1",
-						"istanbul-lib-source-maps": "^1.2.4",
-						"jest-changed-files": "^23.4.2",
-						"jest-config": "^23.6.0",
-						"jest-environment-jsdom": "^23.4.0",
-						"jest-get-type": "^22.1.0",
-						"jest-haste-map": "^23.6.0",
-						"jest-message-util": "^23.4.0",
-						"jest-regex-util": "^23.3.0",
-						"jest-resolve-dependencies": "^23.6.0",
-						"jest-runner": "^23.6.0",
-						"jest-runtime": "^23.6.0",
-						"jest-snapshot": "^23.6.0",
-						"jest-util": "^23.4.0",
-						"jest-validate": "^23.6.0",
-						"jest-watcher": "^23.4.0",
-						"jest-worker": "^23.2.0",
-						"micromatch": "^2.3.11",
-						"node-notifier": "^5.2.1",
-						"prompts": "^0.1.9",
-						"realpath-native": "^1.0.0",
-						"rimraf": "^2.5.4",
-						"slash": "^1.0.0",
-						"string-length": "^2.0.0",
-						"strip-ansi": "^4.0.0",
-						"which": "^1.2.12",
-						"yargs": "^11.0.0"
+						"ansi-escapes": "3.1.0",
+						"chalk": "2.3.2",
+						"exit": "0.1.2",
+						"glob": "7.1.3",
+						"graceful-fs": "4.1.11",
+						"import-local": "1.0.0",
+						"is-ci": "1.1.0",
+						"istanbul-api": "1.3.7",
+						"istanbul-lib-coverage": "1.2.1",
+						"istanbul-lib-instrument": "1.10.2",
+						"istanbul-lib-source-maps": "1.2.6",
+						"jest-changed-files": "23.4.2",
+						"jest-config": "23.6.0",
+						"jest-environment-jsdom": "23.4.0",
+						"jest-get-type": "22.4.3",
+						"jest-haste-map": "23.6.0",
+						"jest-message-util": "23.4.0",
+						"jest-regex-util": "23.3.0",
+						"jest-resolve-dependencies": "23.6.0",
+						"jest-runner": "23.6.0",
+						"jest-runtime": "23.6.0",
+						"jest-snapshot": "23.6.0",
+						"jest-util": "23.4.0",
+						"jest-validate": "23.6.0",
+						"jest-watcher": "23.4.0",
+						"jest-worker": "23.2.0",
+						"micromatch": "2.3.11",
+						"node-notifier": "5.3.0",
+						"prompts": "0.1.14",
+						"realpath-native": "1.0.2",
+						"rimraf": "2.6.2",
+						"slash": "1.0.0",
+						"string-length": "2.0.0",
+						"strip-ansi": "4.0.0",
+						"which": "1.3.1",
+						"yargs": "11.1.0"
 					}
 				}
 			}
@@ -3180,7 +3180,7 @@
 			"integrity": "sha512-EyNhTAUWEfwnK0Is/09LxoqNDOn7mU7S3EHskG52djOFS/z+IT0jT3h3Ql61+dklcG7bJJitIWEMB4Sp1piHmA==",
 			"dev": true,
 			"requires": {
-				"throat": "^4.0.0"
+				"throat": "4.1.0"
 			}
 		},
 		"jest-config": {
@@ -3189,20 +3189,20 @@
 			"integrity": "sha512-i8V7z9BeDXab1+VNo78WM0AtWpBRXJLnkT+lyT+Slx/cbP5sZJ0+NDuLcmBE5hXAoK0aUp7vI+MOxR+R4d8SRQ==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-jest": "^23.6.0",
-				"chalk": "^2.0.1",
-				"glob": "^7.1.1",
-				"jest-environment-jsdom": "^23.4.0",
-				"jest-environment-node": "^23.4.0",
-				"jest-get-type": "^22.1.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
-				"pretty-format": "^23.6.0"
+				"babel-core": "6.26.3",
+				"babel-jest": "23.6.0",
+				"chalk": "2.3.2",
+				"glob": "7.1.3",
+				"jest-environment-jsdom": "23.4.0",
+				"jest-environment-node": "23.4.0",
+				"jest-get-type": "22.4.3",
+				"jest-jasmine2": "23.6.0",
+				"jest-regex-util": "23.3.0",
+				"jest-resolve": "23.6.0",
+				"jest-util": "23.4.0",
+				"jest-validate": "23.6.0",
+				"micromatch": "2.3.11",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-diff": {
@@ -3211,10 +3211,10 @@
 			"integrity": "sha512-Gz9l5Ov+X3aL5L37IT+8hoCUsof1CVYBb2QEkOupK64XyRR3h+uRpYIm97K7sY8diFxowR8pIGEdyfMKTixo3g==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"diff": "^3.2.0",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.3.2",
+				"diff": "3.5.0",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-docblock": {
@@ -3223,7 +3223,7 @@
 			"integrity": "sha1-8IXh8YVI2Z/dabICB+b9VdkTg6c=",
 			"dev": true,
 			"requires": {
-				"detect-newline": "^2.1.0"
+				"detect-newline": "2.1.0"
 			}
 		},
 		"jest-each": {
@@ -3232,8 +3232,8 @@
 			"integrity": "sha512-x7V6M/WGJo6/kLoissORuvLIeAoyo2YqLOoCDkohgJ4XOXSqOtyvr8FbInlAWS77ojBsZrafbozWoKVRdtxFCg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.3.2",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-environment-jsdom": {
@@ -3242,9 +3242,9 @@
 			"integrity": "sha1-BWp5UrP+pROsYqFAosNox52eYCM=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0",
-				"jsdom": "^11.5.1"
+				"jest-mock": "23.2.0",
+				"jest-util": "23.4.0",
+				"jsdom": "11.12.0"
 			}
 		},
 		"jest-environment-node": {
@@ -3253,8 +3253,8 @@
 			"integrity": "sha1-V+gO0IQd6jAxZ8zozXlSHeuv3hA=",
 			"dev": true,
 			"requires": {
-				"jest-mock": "^23.2.0",
-				"jest-util": "^23.4.0"
+				"jest-mock": "23.2.0",
+				"jest-util": "23.4.0"
 			}
 		},
 		"jest-get-type": {
@@ -3269,14 +3269,14 @@
 			"integrity": "sha512-uyNhMyl6dr6HaXGHp8VF7cK6KpC6G9z9LiMNsst+rJIZ8l7wY0tk8qwjPmEghczojZ2/ZhtEdIabZ0OQRJSGGg==",
 			"dev": true,
 			"requires": {
-				"fb-watchman": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"invariant": "^2.2.4",
-				"jest-docblock": "^23.2.0",
-				"jest-serializer": "^23.0.1",
-				"jest-worker": "^23.2.0",
-				"micromatch": "^2.3.11",
-				"sane": "^2.0.0"
+				"fb-watchman": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"invariant": "2.2.4",
+				"jest-docblock": "23.2.0",
+				"jest-serializer": "23.0.1",
+				"jest-worker": "23.2.0",
+				"micromatch": "2.3.11",
+				"sane": "2.5.2"
 			}
 		},
 		"jest-jasmine2": {
@@ -3285,18 +3285,18 @@
 			"integrity": "sha512-pe2Ytgs1nyCs8IvsEJRiRTPC0eVYd8L/dXJGU08GFuBwZ4sYH/lmFDdOL3ZmvJR8QKqV9MFuwlsAi/EWkFUbsQ==",
 			"dev": true,
 			"requires": {
-				"babel-traverse": "^6.0.0",
-				"chalk": "^2.0.1",
-				"co": "^4.6.0",
-				"expect": "^23.6.0",
-				"is-generator-fn": "^1.0.0",
-				"jest-diff": "^23.6.0",
-				"jest-each": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"pretty-format": "^23.6.0"
+				"babel-traverse": "6.26.0",
+				"chalk": "2.3.2",
+				"co": "4.6.0",
+				"expect": "23.6.0",
+				"is-generator-fn": "1.0.0",
+				"jest-diff": "23.6.0",
+				"jest-each": "23.6.0",
+				"jest-matcher-utils": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-snapshot": "23.6.0",
+				"jest-util": "23.4.0",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-leak-detector": {
@@ -3305,7 +3305,7 @@
 			"integrity": "sha512-f/8zA04rsl1Nzj10HIyEsXvYlMpMPcy0QkQilVZDFOaPbv2ur71X5u2+C4ZQJGyV/xvVXtCCZ3wQ99IgQxftCg==",
 			"dev": true,
 			"requires": {
-				"pretty-format": "^23.6.0"
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-matcher-utils": {
@@ -3314,9 +3314,9 @@
 			"integrity": "sha512-rosyCHQfBcol4NsckTn01cdelzWLU9Cq7aaigDf8VwwpIRvWE/9zLgX2bON+FkEW69/0UuYslUe22SOdEf2nog==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.3.2",
+				"jest-get-type": "22.4.3",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-message-util": {
@@ -3325,11 +3325,11 @@
 			"integrity": "sha1-F2EMUJQjSVCNAaPR4L2iwHkIap8=",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.35",
-				"chalk": "^2.0.1",
-				"micromatch": "^2.3.11",
-				"slash": "^1.0.0",
-				"stack-utils": "^1.0.1"
+				"@babel/code-frame": "7.0.0",
+				"chalk": "2.3.2",
+				"micromatch": "2.3.11",
+				"slash": "1.0.0",
+				"stack-utils": "1.0.1"
 			}
 		},
 		"jest-mock": {
@@ -3350,9 +3350,9 @@
 			"integrity": "sha512-XyoRxNtO7YGpQDmtQCmZjum1MljDqUCob7XlZ6jy9gsMugHdN2hY4+Acz9Qvjz2mSsOnPSH7skBmDYCHXVZqkA==",
 			"dev": true,
 			"requires": {
-				"browser-resolve": "^1.11.3",
-				"chalk": "^2.0.1",
-				"realpath-native": "^1.0.0"
+				"browser-resolve": "1.11.3",
+				"chalk": "2.3.2",
+				"realpath-native": "1.0.2"
 			}
 		},
 		"jest-resolve-dependencies": {
@@ -3361,8 +3361,8 @@
 			"integrity": "sha512-EkQWkFWjGKwRtRyIwRwI6rtPAEyPWlUC2MpzHissYnzJeHcyCn1Hc8j7Nn1xUVrS5C6W5+ZL37XTem4D4pLZdA==",
 			"dev": true,
 			"requires": {
-				"jest-regex-util": "^23.3.0",
-				"jest-snapshot": "^23.6.0"
+				"jest-regex-util": "23.3.0",
+				"jest-snapshot": "23.6.0"
 			}
 		},
 		"jest-runner": {
@@ -3371,19 +3371,19 @@
 			"integrity": "sha512-kw0+uj710dzSJKU6ygri851CObtCD9cN8aNkg8jWJf4ewFyEa6kwmiH/r/M1Ec5IL/6VFa0wnAk6w+gzUtjJzA==",
 			"dev": true,
 			"requires": {
-				"exit": "^0.1.2",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-docblock": "^23.2.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-jasmine2": "^23.6.0",
-				"jest-leak-detector": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-runtime": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-worker": "^23.2.0",
-				"source-map-support": "^0.5.6",
-				"throat": "^4.0.0"
+				"exit": "0.1.2",
+				"graceful-fs": "4.1.11",
+				"jest-config": "23.6.0",
+				"jest-docblock": "23.2.0",
+				"jest-haste-map": "23.6.0",
+				"jest-jasmine2": "23.6.0",
+				"jest-leak-detector": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-runtime": "23.6.0",
+				"jest-util": "23.4.0",
+				"jest-worker": "23.2.0",
+				"source-map-support": "0.5.9",
+				"throat": "4.1.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3398,8 +3398,8 @@
 					"integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
 					"dev": true,
 					"requires": {
-						"buffer-from": "^1.0.0",
-						"source-map": "^0.6.0"
+						"buffer-from": "1.1.1",
+						"source-map": "0.6.1"
 					}
 				}
 			}
@@ -3410,27 +3410,27 @@
 			"integrity": "sha512-ycnLTNPT2Gv+TRhnAYAQ0B3SryEXhhRj1kA6hBPSeZaNQkJ7GbZsxOLUkwg6YmvWGdX3BB3PYKFLDQCAE1zNOw==",
 			"dev": true,
 			"requires": {
-				"babel-core": "^6.0.0",
-				"babel-plugin-istanbul": "^4.1.6",
-				"chalk": "^2.0.1",
-				"convert-source-map": "^1.4.0",
-				"exit": "^0.1.2",
-				"fast-json-stable-stringify": "^2.0.0",
-				"graceful-fs": "^4.1.11",
-				"jest-config": "^23.6.0",
-				"jest-haste-map": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-regex-util": "^23.3.0",
-				"jest-resolve": "^23.6.0",
-				"jest-snapshot": "^23.6.0",
-				"jest-util": "^23.4.0",
-				"jest-validate": "^23.6.0",
-				"micromatch": "^2.3.11",
-				"realpath-native": "^1.0.0",
-				"slash": "^1.0.0",
+				"babel-core": "6.26.3",
+				"babel-plugin-istanbul": "4.1.6",
+				"chalk": "2.3.2",
+				"convert-source-map": "1.6.0",
+				"exit": "0.1.2",
+				"fast-json-stable-stringify": "2.0.0",
+				"graceful-fs": "4.1.11",
+				"jest-config": "23.6.0",
+				"jest-haste-map": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-regex-util": "23.3.0",
+				"jest-resolve": "23.6.0",
+				"jest-snapshot": "23.6.0",
+				"jest-util": "23.4.0",
+				"jest-validate": "23.6.0",
+				"micromatch": "2.3.11",
+				"realpath-native": "1.0.2",
+				"slash": "1.0.0",
 				"strip-bom": "3.0.0",
-				"write-file-atomic": "^2.1.0",
-				"yargs": "^11.0.0"
+				"write-file-atomic": "2.3.0",
+				"yargs": "11.1.0"
 			}
 		},
 		"jest-serializer": {
@@ -3445,16 +3445,16 @@
 			"integrity": "sha512-tM7/Bprftun6Cvj2Awh/ikS7zV3pVwjRYU2qNYS51VZHgaAMBs5l4o/69AiDHhQrj5+LA2Lq4VIvK7zYk/bswg==",
 			"dev": true,
 			"requires": {
-				"babel-types": "^6.0.0",
-				"chalk": "^2.0.1",
-				"jest-diff": "^23.6.0",
-				"jest-matcher-utils": "^23.6.0",
-				"jest-message-util": "^23.4.0",
-				"jest-resolve": "^23.6.0",
-				"mkdirp": "^0.5.1",
-				"natural-compare": "^1.4.0",
-				"pretty-format": "^23.6.0",
-				"semver": "^5.5.0"
+				"babel-types": "6.26.0",
+				"chalk": "2.3.2",
+				"jest-diff": "23.6.0",
+				"jest-matcher-utils": "23.6.0",
+				"jest-message-util": "23.4.0",
+				"jest-resolve": "23.6.0",
+				"mkdirp": "0.5.1",
+				"natural-compare": "1.4.0",
+				"pretty-format": "23.6.0",
+				"semver": "5.5.0"
 			}
 		},
 		"jest-util": {
@@ -3463,14 +3463,14 @@
 			"integrity": "sha1-TQY8uSe68KI4Mf9hvsLLv0l5NWE=",
 			"dev": true,
 			"requires": {
-				"callsites": "^2.0.0",
-				"chalk": "^2.0.1",
-				"graceful-fs": "^4.1.11",
-				"is-ci": "^1.0.10",
-				"jest-message-util": "^23.4.0",
-				"mkdirp": "^0.5.1",
-				"slash": "^1.0.0",
-				"source-map": "^0.6.0"
+				"callsites": "2.0.0",
+				"chalk": "2.3.2",
+				"graceful-fs": "4.1.11",
+				"is-ci": "1.1.0",
+				"jest-message-util": "23.4.0",
+				"mkdirp": "0.5.1",
+				"slash": "1.0.0",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -3487,10 +3487,10 @@
 			"integrity": "sha512-OFKapYxe72yz7agrDAWi8v2WL8GIfVqcbKRCLbRG9PAxtzF9b1SEDdTpytNDN12z2fJynoBwpMpvj2R39plI2A==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1",
-				"jest-get-type": "^22.1.0",
-				"leven": "^2.1.0",
-				"pretty-format": "^23.6.0"
+				"chalk": "2.3.2",
+				"jest-get-type": "22.4.3",
+				"leven": "2.1.0",
+				"pretty-format": "23.6.0"
 			}
 		},
 		"jest-watcher": {
@@ -3499,9 +3499,9 @@
 			"integrity": "sha1-0uKM50+NrWxq/JIrksq+9u0FyRw=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^3.0.0",
-				"chalk": "^2.0.1",
-				"string-length": "^2.0.0"
+				"ansi-escapes": "3.1.0",
+				"chalk": "2.3.2",
+				"string-length": "2.0.0"
 			}
 		},
 		"jest-worker": {
@@ -3510,7 +3510,7 @@
 			"integrity": "sha1-+vcGqNo2+uYOsmlXJX+ntdjqArk=",
 			"dev": true,
 			"requires": {
-				"merge-stream": "^1.0.1"
+				"merge-stream": "1.0.1"
 			}
 		},
 		"js-tokens": {
@@ -3525,8 +3525,8 @@
 			"integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
 			"dev": true,
 			"requires": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
+				"argparse": "1.0.10",
+				"esprima": "4.0.1"
 			}
 		},
 		"jsbn": {
@@ -3541,32 +3541,32 @@
 			"integrity": "sha512-y8Px43oyiBM13Zc1z780FrfNLJCXTL40EWlty/LXUtcjykRBNgLlCjWXpfSPBl2iv+N7koQN+dvqszHZgT/Fjw==",
 			"dev": true,
 			"requires": {
-				"abab": "^2.0.0",
-				"acorn": "^5.5.3",
-				"acorn-globals": "^4.1.0",
-				"array-equal": "^1.0.0",
-				"cssom": ">= 0.3.2 < 0.4.0",
-				"cssstyle": "^1.0.0",
-				"data-urls": "^1.0.0",
-				"domexception": "^1.0.1",
-				"escodegen": "^1.9.1",
-				"html-encoding-sniffer": "^1.0.2",
-				"left-pad": "^1.3.0",
-				"nwsapi": "^2.0.7",
+				"abab": "2.0.0",
+				"acorn": "5.7.3",
+				"acorn-globals": "4.3.0",
+				"array-equal": "1.0.0",
+				"cssom": "0.3.4",
+				"cssstyle": "1.1.1",
+				"data-urls": "1.1.0",
+				"domexception": "1.0.1",
+				"escodegen": "1.11.0",
+				"html-encoding-sniffer": "1.0.2",
+				"left-pad": "1.3.0",
+				"nwsapi": "2.0.9",
 				"parse5": "4.0.0",
-				"pn": "^1.1.0",
-				"request": "^2.87.0",
-				"request-promise-native": "^1.0.5",
-				"sax": "^1.2.4",
-				"symbol-tree": "^3.2.2",
-				"tough-cookie": "^2.3.4",
-				"w3c-hr-time": "^1.0.1",
-				"webidl-conversions": "^4.0.2",
-				"whatwg-encoding": "^1.0.3",
-				"whatwg-mimetype": "^2.1.0",
-				"whatwg-url": "^6.4.1",
-				"ws": "^5.2.0",
-				"xml-name-validator": "^3.0.0"
+				"pn": "1.1.0",
+				"request": "2.88.0",
+				"request-promise-native": "1.0.5",
+				"sax": "1.2.4",
+				"symbol-tree": "3.2.2",
+				"tough-cookie": "2.4.3",
+				"w3c-hr-time": "1.0.1",
+				"webidl-conversions": "4.0.2",
+				"whatwg-encoding": "1.0.5",
+				"whatwg-mimetype": "2.2.0",
+				"whatwg-url": "6.5.0",
+				"ws": "5.2.2",
+				"xml-name-validator": "3.0.0"
 			}
 		},
 		"jsesc": {
@@ -3629,7 +3629,7 @@
 			"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 			"dev": true,
 			"requires": {
-				"is-buffer": "^1.1.5"
+				"is-buffer": "1.1.6"
 			}
 		},
 		"kleur": {
@@ -3643,7 +3643,7 @@
 			"resolved": "https://registry.npmjs.org/kuler/-/kuler-1.0.1.tgz",
 			"integrity": "sha512-J9nVUucG1p/skKul6DU3PUZrhs0LPulNaeUOox0IyXDi8S4CztTHs1gQphhuZmzXG7VOQSf6NJfKuzteQLv9gQ==",
 			"requires": {
-				"colornames": "^1.1.1"
+				"colornames": "1.1.1"
 			}
 		},
 		"lcid": {
@@ -3652,7 +3652,7 @@
 			"integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
 			"dev": true,
 			"requires": {
-				"invert-kv": "^1.0.0"
+				"invert-kv": "1.0.0"
 			}
 		},
 		"left-pad": {
@@ -3673,8 +3673,8 @@
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2"
 			}
 		},
 		"lint-staged": {
@@ -3683,28 +3683,28 @@
 			"integrity": "sha512-AXk40M9DAiPi7f4tdJggwuKIViUplYtVj1os1MVEteW7qOkU50EOehayCfO9TsoGK24o/EsWb41yrEgfJDDjCw==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.3.1",
-				"commander": "^2.14.1",
-				"cosmiconfig": "^5.0.2",
-				"debug": "^3.1.0",
-				"dedent": "^0.7.0",
-				"execa": "^0.9.0",
-				"find-parent-dir": "^0.3.0",
-				"is-glob": "^4.0.0",
-				"is-windows": "^1.0.2",
-				"jest-validate": "^23.5.0",
-				"listr": "^0.14.1",
-				"lodash": "^4.17.5",
-				"log-symbols": "^2.2.0",
-				"micromatch": "^3.1.8",
-				"npm-which": "^3.0.1",
-				"p-map": "^1.1.1",
-				"path-is-inside": "^1.0.2",
-				"pify": "^3.0.0",
-				"please-upgrade-node": "^3.0.2",
+				"chalk": "2.3.2",
+				"commander": "2.17.1",
+				"cosmiconfig": "5.0.6",
+				"debug": "3.2.6",
+				"dedent": "0.7.0",
+				"execa": "0.9.0",
+				"find-parent-dir": "0.3.0",
+				"is-glob": "4.0.0",
+				"is-windows": "1.0.2",
+				"jest-validate": "23.6.0",
+				"listr": "0.14.2",
+				"lodash": "4.17.11",
+				"log-symbols": "2.2.0",
+				"micromatch": "3.1.10",
+				"npm-which": "3.0.1",
+				"p-map": "1.2.0",
+				"path-is-inside": "1.0.2",
+				"pify": "3.0.0",
+				"please-upgrade-node": "3.1.1",
 				"staged-git-files": "1.1.1",
-				"string-argv": "^0.0.2",
-				"stringify-object": "^3.2.2"
+				"string-argv": "0.0.2",
+				"stringify-object": "3.3.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -3725,16 +3725,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3743,7 +3743,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -3754,7 +3754,7 @@
 					"integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
 					"dev": true,
 					"requires": {
-						"ms": "^2.1.1"
+						"ms": "2.1.1"
 					}
 				},
 				"execa": {
@@ -3763,13 +3763,13 @@
 					"integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
 					"dev": true,
 					"requires": {
-						"cross-spawn": "^5.0.1",
-						"get-stream": "^3.0.0",
-						"is-stream": "^1.1.0",
-						"npm-run-path": "^2.0.0",
-						"p-finally": "^1.0.0",
-						"signal-exit": "^3.0.0",
-						"strip-eof": "^1.0.0"
+						"cross-spawn": "5.1.0",
+						"get-stream": "3.0.0",
+						"is-stream": "1.1.0",
+						"npm-run-path": "2.0.2",
+						"p-finally": "1.0.0",
+						"signal-exit": "3.0.2",
+						"strip-eof": "1.0.0"
 					}
 				},
 				"expand-brackets": {
@@ -3778,13 +3778,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"debug": {
@@ -3802,7 +3802,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -3811,7 +3811,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -3820,7 +3820,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3829,7 +3829,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -3840,7 +3840,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -3849,7 +3849,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -3860,9 +3860,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -3885,14 +3885,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -3901,7 +3901,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -3910,7 +3910,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -3921,10 +3921,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -3933,7 +3933,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -3944,7 +3944,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -3953,7 +3953,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -3962,9 +3962,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-extglob": {
@@ -3979,7 +3979,7 @@
 					"integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
 					"dev": true,
 					"requires": {
-						"is-extglob": "^2.1.1"
+						"is-extglob": "2.1.1"
 					}
 				},
 				"is-number": {
@@ -3988,7 +3988,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -3997,7 +3997,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -4020,19 +4020,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"ms": {
@@ -4049,15 +4049,15 @@
 			"integrity": "sha512-vmaNJ1KlGuGWShHI35X/F8r9xxS0VTHh9GejVXwSN20fG5xpq3Jh4bJbnumoT6q5EDM/8/YP1z3YMtQbFmhuXw==",
 			"dev": true,
 			"requires": {
-				"@samverschueren/stream-to-observable": "^0.3.0",
-				"is-observable": "^1.1.0",
-				"is-promise": "^2.1.0",
-				"is-stream": "^1.1.0",
-				"listr-silent-renderer": "^1.1.1",
-				"listr-update-renderer": "^0.4.0",
-				"listr-verbose-renderer": "^0.4.0",
-				"p-map": "^1.1.1",
-				"rxjs": "^6.1.0"
+				"@samverschueren/stream-to-observable": "0.3.0",
+				"is-observable": "1.1.0",
+				"is-promise": "2.1.0",
+				"is-stream": "1.1.0",
+				"listr-silent-renderer": "1.1.1",
+				"listr-update-renderer": "0.4.0",
+				"listr-verbose-renderer": "0.4.1",
+				"p-map": "1.2.0",
+				"rxjs": "6.3.3"
 			}
 		},
 		"listr-silent-renderer": {
@@ -4072,14 +4072,14 @@
 			"integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-truncate": "^0.2.1",
-				"elegant-spinner": "^1.0.1",
-				"figures": "^1.7.0",
-				"indent-string": "^3.0.0",
-				"log-symbols": "^1.0.2",
-				"log-update": "^1.0.2",
-				"strip-ansi": "^3.0.1"
+				"chalk": "1.1.3",
+				"cli-truncate": "0.2.1",
+				"elegant-spinner": "1.0.1",
+				"figures": "1.7.0",
+				"indent-string": "3.2.0",
+				"log-symbols": "1.0.2",
+				"log-update": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"chalk": {
@@ -4088,11 +4088,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"log-symbols": {
@@ -4101,7 +4101,7 @@
 					"integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
 					"dev": true,
 					"requires": {
-						"chalk": "^1.0.0"
+						"chalk": "1.1.3"
 					}
 				},
 				"strip-ansi": {
@@ -4110,7 +4110,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				}
 			}
@@ -4121,10 +4121,10 @@
 			"integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
 			"dev": true,
 			"requires": {
-				"chalk": "^1.1.3",
-				"cli-cursor": "^1.0.2",
-				"date-fns": "^1.27.2",
-				"figures": "^1.7.0"
+				"chalk": "1.1.3",
+				"cli-cursor": "1.0.2",
+				"date-fns": "1.29.0",
+				"figures": "1.7.0"
 			},
 			"dependencies": {
 				"chalk": {
@@ -4133,11 +4133,11 @@
 					"integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "2.2.1",
+						"escape-string-regexp": "1.0.5",
+						"has-ansi": "2.0.0",
+						"strip-ansi": "3.0.1",
+						"supports-color": "2.0.0"
 					}
 				},
 				"strip-ansi": {
@@ -4146,7 +4146,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				}
 			}
@@ -4157,10 +4157,10 @@
 			"integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.2",
-				"parse-json": "^4.0.0",
-				"pify": "^3.0.0",
-				"strip-bom": "^3.0.0"
+				"graceful-fs": "4.1.11",
+				"parse-json": "4.0.0",
+				"pify": "3.0.0",
+				"strip-bom": "3.0.0"
 			}
 		},
 		"locate-path": {
@@ -4169,8 +4169,8 @@
 			"integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
 			"dev": true,
 			"requires": {
-				"p-locate": "^2.0.0",
-				"path-exists": "^3.0.0"
+				"p-locate": "2.0.0",
+				"path-exists": "3.0.0"
 			}
 		},
 		"lodash": {
@@ -4190,7 +4190,7 @@
 			"integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.0.1"
+				"chalk": "2.3.2"
 			}
 		},
 		"log-update": {
@@ -4199,8 +4199,8 @@
 			"integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
 			"dev": true,
 			"requires": {
-				"ansi-escapes": "^1.0.0",
-				"cli-cursor": "^1.0.2"
+				"ansi-escapes": "1.4.0",
+				"cli-cursor": "1.0.2"
 			},
 			"dependencies": {
 				"ansi-escapes": {
@@ -4216,11 +4216,11 @@
 			"resolved": "https://registry.npmjs.org/logform/-/logform-1.10.0.tgz",
 			"integrity": "sha512-em5ojIhU18fIMOw/333mD+ZLE2fis0EzXl1ZwHx4iQzmpQi6odNiY/t+ITNr33JZhT9/KEaH+UPIipr6a9EjWg==",
 			"requires": {
-				"colors": "^1.2.1",
-				"fast-safe-stringify": "^2.0.4",
-				"fecha": "^2.3.3",
-				"ms": "^2.1.1",
-				"triple-beam": "^1.2.0"
+				"colors": "1.3.2",
+				"fast-safe-stringify": "2.0.6",
+				"fecha": "2.3.3",
+				"ms": "2.1.1",
+				"triple-beam": "1.3.0"
 			},
 			"dependencies": {
 				"ms": {
@@ -4236,7 +4236,7 @@
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
 			"dev": true,
 			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
+				"js-tokens": "3.0.2"
 			}
 		},
 		"lru-cache": {
@@ -4245,8 +4245,8 @@
 			"integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
 			"dev": true,
 			"requires": {
-				"pseudomap": "^1.0.2",
-				"yallist": "^2.1.2"
+				"pseudomap": "1.0.2",
+				"yallist": "2.1.2"
 			}
 		},
 		"make-error": {
@@ -4261,7 +4261,7 @@
 			"integrity": "sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=",
 			"dev": true,
 			"requires": {
-				"tmpl": "1.0.x"
+				"tmpl": "1.0.4"
 			}
 		},
 		"map-cache": {
@@ -4282,7 +4282,7 @@
 			"integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
 			"dev": true,
 			"requires": {
-				"object-visit": "^1.0.0"
+				"object-visit": "1.0.1"
 			}
 		},
 		"math-random": {
@@ -4297,7 +4297,7 @@
 			"integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
 			"dev": true,
 			"requires": {
-				"mimic-fn": "^1.0.0"
+				"mimic-fn": "1.2.0"
 			}
 		},
 		"memorystream": {
@@ -4318,7 +4318,7 @@
 			"integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
 			"dev": true,
 			"requires": {
-				"readable-stream": "^2.0.1"
+				"readable-stream": "2.3.6"
 			}
 		},
 		"micromatch": {
@@ -4327,19 +4327,19 @@
 			"integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^2.0.0",
-				"array-unique": "^0.2.1",
-				"braces": "^1.8.2",
-				"expand-brackets": "^0.1.4",
-				"extglob": "^0.3.1",
-				"filename-regex": "^2.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.1",
-				"kind-of": "^3.0.2",
-				"normalize-path": "^2.0.1",
-				"object.omit": "^2.0.0",
-				"parse-glob": "^3.0.4",
-				"regex-cache": "^0.4.2"
+				"arr-diff": "2.0.0",
+				"array-unique": "0.2.1",
+				"braces": "1.8.5",
+				"expand-brackets": "0.1.5",
+				"extglob": "0.3.2",
+				"filename-regex": "2.0.1",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1",
+				"kind-of": "3.2.2",
+				"normalize-path": "2.1.1",
+				"object.omit": "2.0.1",
+				"parse-glob": "3.0.4",
+				"regex-cache": "0.4.4"
 			},
 			"dependencies": {
 				"normalize-path": {
@@ -4348,7 +4348,7 @@
 					"integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
 					"dev": true,
 					"requires": {
-						"remove-trailing-separator": "^1.0.1"
+						"remove-trailing-separator": "1.1.0"
 					}
 				}
 			}
@@ -4365,7 +4365,7 @@
 			"integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
 			"dev": true,
 			"requires": {
-				"mime-db": "~1.37.0"
+				"mime-db": "1.37.0"
 			}
 		},
 		"mimic-fn": {
@@ -4380,7 +4380,7 @@
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"requires": {
-				"brace-expansion": "^1.1.7"
+				"brace-expansion": "1.1.11"
 			}
 		},
 		"minimist": {
@@ -4395,8 +4395,8 @@
 			"integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
 			"dev": true,
 			"requires": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
+				"for-in": "1.0.2",
+				"is-extendable": "1.0.1"
 			},
 			"dependencies": {
 				"is-extendable": {
@@ -4405,7 +4405,7 @@
 					"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
 					"dev": true,
 					"requires": {
-						"is-plain-object": "^2.0.4"
+						"is-plain-object": "2.0.4"
 					}
 				}
 			}
@@ -4438,17 +4438,17 @@
 			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
 			"dev": true,
 			"requires": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
+				"arr-diff": "4.0.0",
+				"array-unique": "0.3.2",
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"fragment-cache": "0.2.1",
+				"is-windows": "1.0.2",
+				"kind-of": "6.0.2",
+				"object.pick": "1.3.0",
+				"regex-not": "1.0.2",
+				"snapdragon": "0.8.2",
+				"to-regex": "3.0.2"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -4495,10 +4495,10 @@
 			"integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
 			"dev": true,
 			"requires": {
-				"growly": "^1.3.0",
-				"semver": "^5.5.0",
-				"shellwords": "^0.1.1",
-				"which": "^1.3.0"
+				"growly": "1.3.0",
+				"semver": "5.5.0",
+				"shellwords": "0.1.1",
+				"which": "1.3.1"
 			}
 		},
 		"normalize-package-data": {
@@ -4507,10 +4507,10 @@
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"dev": true,
 			"requires": {
-				"hosted-git-info": "^2.1.4",
-				"is-builtin-module": "^1.0.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
+				"hosted-git-info": "2.6.0",
+				"is-builtin-module": "1.0.0",
+				"semver": "5.5.0",
+				"validate-npm-package-license": "3.0.3"
 			}
 		},
 		"normalize-path": {
@@ -4525,7 +4525,7 @@
 			"integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
 			"dev": true,
 			"requires": {
-				"which": "^1.2.10"
+				"which": "1.3.1"
 			}
 		},
 		"npm-run-all": {
@@ -4534,15 +4534,15 @@
 			"integrity": "sha512-aOG0N3Eo/WW+q6sUIdzcV2COS8VnTZCmdji0VQIAZF3b+a3YWb0AD0vFIyjKec18A7beLGbaQ5jFTNI2bPt9Cg==",
 			"dev": true,
 			"requires": {
-				"ansi-styles": "^3.2.0",
-				"chalk": "^2.1.0",
-				"cross-spawn": "^6.0.4",
-				"memorystream": "^0.3.1",
-				"minimatch": "^3.0.4",
-				"ps-tree": "^1.1.0",
-				"read-pkg": "^3.0.0",
-				"shell-quote": "^1.6.1",
-				"string.prototype.padend": "^3.0.0"
+				"ansi-styles": "3.2.1",
+				"chalk": "2.3.2",
+				"cross-spawn": "6.0.5",
+				"memorystream": "0.3.1",
+				"minimatch": "3.0.4",
+				"ps-tree": "1.1.0",
+				"read-pkg": "3.0.0",
+				"shell-quote": "1.6.1",
+				"string.prototype.padend": "3.0.0"
 			},
 			"dependencies": {
 				"ansi-styles": {
@@ -4551,7 +4551,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				},
 				"cross-spawn": {
@@ -4560,11 +4560,11 @@
 					"integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
 					"dev": true,
 					"requires": {
-						"nice-try": "^1.0.4",
-						"path-key": "^2.0.1",
-						"semver": "^5.5.0",
-						"shebang-command": "^1.2.0",
-						"which": "^1.2.9"
+						"nice-try": "1.0.4",
+						"path-key": "2.0.1",
+						"semver": "5.5.0",
+						"shebang-command": "1.2.0",
+						"which": "1.3.1"
 					}
 				}
 			}
@@ -4575,7 +4575,7 @@
 			"integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
 			"dev": true,
 			"requires": {
-				"path-key": "^2.0.0"
+				"path-key": "2.0.1"
 			}
 		},
 		"npm-which": {
@@ -4584,9 +4584,9 @@
 			"integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
 			"dev": true,
 			"requires": {
-				"commander": "^2.9.0",
-				"npm-path": "^2.0.2",
-				"which": "^1.2.10"
+				"commander": "2.17.1",
+				"npm-path": "2.0.4",
+				"which": "1.3.1"
 			}
 		},
 		"number-is-nan": {
@@ -4619,9 +4619,9 @@
 			"integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
 			"dev": true,
 			"requires": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
+				"copy-descriptor": "0.1.1",
+				"define-property": "0.2.5",
+				"kind-of": "3.2.2"
 			},
 			"dependencies": {
 				"define-property": {
@@ -4630,7 +4630,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -4647,7 +4647,7 @@
 			"integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.0"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4664,8 +4664,8 @@
 			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.12.0"
 			}
 		},
 		"object.omit": {
@@ -4674,8 +4674,8 @@
 			"integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
 			"dev": true,
 			"requires": {
-				"for-own": "^0.1.4",
-				"is-extendable": "^0.1.1"
+				"for-own": "0.1.5",
+				"is-extendable": "0.1.1"
 			}
 		},
 		"object.pick": {
@@ -4684,7 +4684,7 @@
 			"integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
 			"dev": true,
 			"requires": {
-				"isobject": "^3.0.1"
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"isobject": {
@@ -4701,7 +4701,7 @@
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"requires": {
-				"wrappy": "1"
+				"wrappy": "1.0.2"
 			}
 		},
 		"one-time": {
@@ -4721,8 +4721,8 @@
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"dev": true,
 			"requires": {
-				"minimist": "~0.0.1",
-				"wordwrap": "~0.0.2"
+				"minimist": "0.0.8",
+				"wordwrap": "0.0.3"
 			}
 		},
 		"optionator": {
@@ -4731,12 +4731,12 @@
 			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "0.1.3",
+				"fast-levenshtein": "2.0.6",
+				"levn": "0.3.0",
+				"prelude-ls": "1.1.2",
+				"type-check": "0.3.2",
+				"wordwrap": "1.0.0"
 			},
 			"dependencies": {
 				"wordwrap": {
@@ -4759,9 +4759,9 @@
 			"integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
 			"dev": true,
 			"requires": {
-				"execa": "^0.7.0",
-				"lcid": "^1.0.0",
-				"mem": "^1.1.0"
+				"execa": "0.7.0",
+				"lcid": "1.0.0",
+				"mem": "1.1.0"
 			}
 		},
 		"os-tmpdir": {
@@ -4782,7 +4782,7 @@
 			"integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
 			"dev": true,
 			"requires": {
-				"p-try": "^1.0.0"
+				"p-try": "1.0.0"
 			}
 		},
 		"p-locate": {
@@ -4791,7 +4791,7 @@
 			"integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
 			"dev": true,
 			"requires": {
-				"p-limit": "^1.1.0"
+				"p-limit": "1.3.0"
 			}
 		},
 		"p-map": {
@@ -4812,10 +4812,10 @@
 			"integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
 			"dev": true,
 			"requires": {
-				"glob-base": "^0.3.0",
-				"is-dotfile": "^1.0.0",
-				"is-extglob": "^1.0.0",
-				"is-glob": "^2.0.0"
+				"glob-base": "0.3.0",
+				"is-dotfile": "1.0.3",
+				"is-extglob": "1.0.0",
+				"is-glob": "2.0.1"
 			}
 		},
 		"parse-json": {
@@ -4824,8 +4824,8 @@
 			"integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
 			"dev": true,
 			"requires": {
-				"error-ex": "^1.3.1",
-				"json-parse-better-errors": "^1.0.1"
+				"error-ex": "1.3.1",
+				"json-parse-better-errors": "1.0.2"
 			}
 		},
 		"parse5": {
@@ -4876,7 +4876,7 @@
 			"integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
 			"dev": true,
 			"requires": {
-				"pify": "^3.0.0"
+				"pify": "3.0.0"
 			}
 		},
 		"pause-stream": {
@@ -4885,7 +4885,7 @@
 			"integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
 			"dev": true,
 			"requires": {
-				"through": "~2.3"
+				"through": "2.3.8"
 			}
 		},
 		"performance-now": {
@@ -4912,7 +4912,7 @@
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"dev": true,
 			"requires": {
-				"pinkie": "^2.0.0"
+				"pinkie": "2.0.4"
 			}
 		},
 		"pkg-dir": {
@@ -4921,7 +4921,7 @@
 			"integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
 			"dev": true,
 			"requires": {
-				"find-up": "^2.1.0"
+				"find-up": "2.1.0"
 			}
 		},
 		"please-upgrade-node": {
@@ -4930,7 +4930,7 @@
 			"integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
 			"dev": true,
 			"requires": {
-				"semver-compare": "^1.0.0"
+				"semver-compare": "1.0.0"
 			}
 		},
 		"pn": {
@@ -4969,8 +4969,8 @@
 			"integrity": "sha512-zf9NV1NSlDLDjycnwm6hpFATCGl/K1lt0R/GdkAK2O5LN/rwJoB+Mh93gGJjut4YbmecbfgLWVGSTCr0Ewvvbw==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0",
-				"ansi-styles": "^3.2.0"
+				"ansi-regex": "3.0.0",
+				"ansi-styles": "3.2.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4985,7 +4985,7 @@
 					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 					"dev": true,
 					"requires": {
-						"color-convert": "^1.9.0"
+						"color-convert": "1.9.1"
 					}
 				}
 			}
@@ -5007,8 +5007,8 @@
 			"integrity": "sha512-rxkyiE9YH6zAz/rZpywySLKkpaj0NMVyNw1qhsubdbjjSgcayjTShDreZGlFMcGSu5sab3bAKPfFk78PB90+8w==",
 			"dev": true,
 			"requires": {
-				"kleur": "^2.0.1",
-				"sisteransi": "^0.1.1"
+				"kleur": "2.0.2",
+				"sisteransi": "0.1.1"
 			}
 		},
 		"ps-tree": {
@@ -5017,7 +5017,7 @@
 			"integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
 			"dev": true,
 			"requires": {
-				"event-stream": "~3.3.0"
+				"event-stream": "3.3.4"
 			}
 		},
 		"pseudomap": {
@@ -5050,9 +5050,9 @@
 			"integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
 			"dev": true,
 			"requires": {
-				"is-number": "^4.0.0",
-				"kind-of": "^6.0.0",
-				"math-random": "^1.0.1"
+				"is-number": "4.0.0",
+				"kind-of": "6.0.2",
+				"math-random": "1.0.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -5075,9 +5075,9 @@
 			"integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
 			"dev": true,
 			"requires": {
-				"load-json-file": "^4.0.0",
-				"normalize-package-data": "^2.3.2",
-				"path-type": "^3.0.0"
+				"load-json-file": "4.0.0",
+				"normalize-package-data": "2.4.0",
+				"path-type": "3.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -5086,8 +5086,8 @@
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"dev": true,
 			"requires": {
-				"find-up": "^1.0.0",
-				"read-pkg": "^1.0.0"
+				"find-up": "1.1.2",
+				"read-pkg": "1.1.0"
 			},
 			"dependencies": {
 				"find-up": {
@@ -5096,8 +5096,8 @@
 					"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 					"dev": true,
 					"requires": {
-						"path-exists": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"path-exists": "2.1.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"load-json-file": {
@@ -5106,11 +5106,11 @@
 					"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"parse-json": "^2.2.0",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0",
-						"strip-bom": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"parse-json": "2.2.0",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1",
+						"strip-bom": "2.0.0"
 					}
 				},
 				"parse-json": {
@@ -5119,7 +5119,7 @@
 					"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 					"dev": true,
 					"requires": {
-						"error-ex": "^1.2.0"
+						"error-ex": "1.3.1"
 					}
 				},
 				"path-exists": {
@@ -5128,7 +5128,7 @@
 					"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 					"dev": true,
 					"requires": {
-						"pinkie-promise": "^2.0.0"
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"path-type": {
@@ -5137,9 +5137,9 @@
 					"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 					"dev": true,
 					"requires": {
-						"graceful-fs": "^4.1.2",
-						"pify": "^2.0.0",
-						"pinkie-promise": "^2.0.0"
+						"graceful-fs": "4.1.11",
+						"pify": "2.3.0",
+						"pinkie-promise": "2.0.1"
 					}
 				},
 				"pify": {
@@ -5154,9 +5154,9 @@
 					"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 					"dev": true,
 					"requires": {
-						"load-json-file": "^1.0.0",
-						"normalize-package-data": "^2.3.2",
-						"path-type": "^1.0.0"
+						"load-json-file": "1.1.0",
+						"normalize-package-data": "2.4.0",
+						"path-type": "1.1.0"
 					}
 				},
 				"strip-bom": {
@@ -5165,7 +5165,7 @@
 					"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 					"dev": true,
 					"requires": {
-						"is-utf8": "^0.2.0"
+						"is-utf8": "0.2.1"
 					}
 				}
 			}
@@ -5175,13 +5175,13 @@
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
+				"core-util-is": "1.0.2",
+				"inherits": "2.0.3",
+				"isarray": "1.0.0",
+				"process-nextick-args": "2.0.0",
+				"safe-buffer": "5.1.2",
+				"string_decoder": "1.1.1",
+				"util-deprecate": "1.0.2"
 			}
 		},
 		"realpath-native": {
@@ -5190,7 +5190,7 @@
 			"integrity": "sha512-+S3zTvVt9yTntFrBpm7TQmQ3tzpCrnA1a/y+3cUHAc9ZR6aIjG0WNLR+Rj79QpJktY+VeW/TQtFlQ1bzsehI8g==",
 			"dev": true,
 			"requires": {
-				"util.promisify": "^1.0.0"
+				"util.promisify": "1.0.0"
 			}
 		},
 		"regenerator-runtime": {
@@ -5205,7 +5205,7 @@
 			"integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
 			"dev": true,
 			"requires": {
-				"is-equal-shallow": "^0.1.3"
+				"is-equal-shallow": "0.1.3"
 			}
 		},
 		"regex-not": {
@@ -5214,8 +5214,8 @@
 			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
+				"extend-shallow": "3.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"remove-trailing-separator": {
@@ -5242,7 +5242,7 @@
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"dev": true,
 			"requires": {
-				"is-finite": "^1.0.0"
+				"is-finite": "1.0.2"
 			}
 		},
 		"request": {
@@ -5251,26 +5251,26 @@
 			"integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
 			"dev": true,
 			"requires": {
-				"aws-sign2": "~0.7.0",
-				"aws4": "^1.8.0",
-				"caseless": "~0.12.0",
-				"combined-stream": "~1.0.6",
-				"extend": "~3.0.2",
-				"forever-agent": "~0.6.1",
-				"form-data": "~2.3.2",
-				"har-validator": "~5.1.0",
-				"http-signature": "~1.2.0",
-				"is-typedarray": "~1.0.0",
-				"isstream": "~0.1.2",
-				"json-stringify-safe": "~5.0.1",
-				"mime-types": "~2.1.19",
-				"oauth-sign": "~0.9.0",
-				"performance-now": "^2.1.0",
-				"qs": "~6.5.2",
-				"safe-buffer": "^5.1.2",
-				"tough-cookie": "~2.4.3",
-				"tunnel-agent": "^0.6.0",
-				"uuid": "^3.3.2"
+				"aws-sign2": "0.7.0",
+				"aws4": "1.8.0",
+				"caseless": "0.12.0",
+				"combined-stream": "1.0.7",
+				"extend": "3.0.2",
+				"forever-agent": "0.6.1",
+				"form-data": "2.3.3",
+				"har-validator": "5.1.0",
+				"http-signature": "1.2.0",
+				"is-typedarray": "1.0.0",
+				"isstream": "0.1.2",
+				"json-stringify-safe": "5.0.1",
+				"mime-types": "2.1.21",
+				"oauth-sign": "0.9.0",
+				"performance-now": "2.1.0",
+				"qs": "6.5.2",
+				"safe-buffer": "5.1.2",
+				"tough-cookie": "2.4.3",
+				"tunnel-agent": "0.6.0",
+				"uuid": "3.3.2"
 			}
 		},
 		"request-promise-core": {
@@ -5279,7 +5279,7 @@
 			"integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.13.1"
+				"lodash": "4.17.11"
 			}
 		},
 		"request-promise-native": {
@@ -5289,8 +5289,8 @@
 			"dev": true,
 			"requires": {
 				"request-promise-core": "1.1.1",
-				"stealthy-require": "^1.1.0",
-				"tough-cookie": ">=2.3.3"
+				"stealthy-require": "1.1.1",
+				"tough-cookie": "2.4.3"
 			}
 		},
 		"require-directory": {
@@ -5317,7 +5317,7 @@
 			"integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
 			"dev": true,
 			"requires": {
-				"resolve-from": "^3.0.0"
+				"resolve-from": "3.0.0"
 			}
 		},
 		"resolve-from": {
@@ -5338,8 +5338,8 @@
 			"integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
 			"dev": true,
 			"requires": {
-				"exit-hook": "^1.0.0",
-				"onetime": "^1.0.0"
+				"exit-hook": "1.1.1",
+				"onetime": "1.1.0"
 			}
 		},
 		"ret": {
@@ -5354,7 +5354,7 @@
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"dev": true,
 			"requires": {
-				"glob": "^7.0.5"
+				"glob": "7.1.3"
 			}
 		},
 		"rsvp": {
@@ -5369,7 +5369,7 @@
 			"integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.9.0"
+				"tslib": "1.9.3"
 			}
 		},
 		"safe-buffer": {
@@ -5383,7 +5383,7 @@
 			"integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
 			"dev": true,
 			"requires": {
-				"ret": "~0.1.10"
+				"ret": "0.1.15"
 			}
 		},
 		"safer-buffer": {
@@ -5398,15 +5398,15 @@
 			"integrity": "sha1-tNwYYcIbQn6SlQej51HiosuKs/o=",
 			"dev": true,
 			"requires": {
-				"anymatch": "^2.0.0",
-				"capture-exit": "^1.2.0",
-				"exec-sh": "^0.2.0",
-				"fb-watchman": "^2.0.0",
-				"fsevents": "^1.2.3",
-				"micromatch": "^3.1.4",
-				"minimist": "^1.1.1",
-				"walker": "~1.0.5",
-				"watch": "~0.18.0"
+				"anymatch": "2.0.0",
+				"capture-exit": "1.2.0",
+				"exec-sh": "0.2.2",
+				"fb-watchman": "2.0.0",
+				"fsevents": "1.2.4",
+				"micromatch": "3.1.10",
+				"minimist": "1.2.0",
+				"walker": "1.0.7",
+				"watch": "0.18.0"
 			},
 			"dependencies": {
 				"arr-diff": {
@@ -5427,16 +5427,16 @@
 					"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
 					"dev": true,
 					"requires": {
-						"arr-flatten": "^1.1.0",
-						"array-unique": "^0.3.2",
-						"extend-shallow": "^2.0.1",
-						"fill-range": "^4.0.0",
-						"isobject": "^3.0.1",
-						"repeat-element": "^1.1.2",
-						"snapdragon": "^0.8.1",
-						"snapdragon-node": "^2.0.1",
-						"split-string": "^3.0.2",
-						"to-regex": "^3.0.1"
+						"arr-flatten": "1.1.0",
+						"array-unique": "0.3.2",
+						"extend-shallow": "2.0.1",
+						"fill-range": "4.0.0",
+						"isobject": "3.0.1",
+						"repeat-element": "1.1.3",
+						"snapdragon": "0.8.2",
+						"snapdragon-node": "2.1.1",
+						"split-string": "3.1.0",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -5445,7 +5445,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5456,13 +5456,13 @@
 					"integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
 					"dev": true,
 					"requires": {
-						"debug": "^2.3.3",
-						"define-property": "^0.2.5",
-						"extend-shallow": "^2.0.1",
-						"posix-character-classes": "^0.1.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"debug": "2.6.9",
+						"define-property": "0.2.5",
+						"extend-shallow": "2.0.1",
+						"posix-character-classes": "0.1.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -5471,7 +5471,7 @@
 							"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^0.1.0"
+								"is-descriptor": "0.1.6"
 							}
 						},
 						"extend-shallow": {
@@ -5480,7 +5480,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						},
 						"is-accessor-descriptor": {
@@ -5489,7 +5489,7 @@
 							"integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -5498,7 +5498,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -5509,7 +5509,7 @@
 							"integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
 							"dev": true,
 							"requires": {
-								"kind-of": "^3.0.2"
+								"kind-of": "3.2.2"
 							},
 							"dependencies": {
 								"kind-of": {
@@ -5518,7 +5518,7 @@
 									"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 									"dev": true,
 									"requires": {
-										"is-buffer": "^1.1.5"
+										"is-buffer": "1.1.6"
 									}
 								}
 							}
@@ -5529,9 +5529,9 @@
 							"integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
 							"dev": true,
 							"requires": {
-								"is-accessor-descriptor": "^0.1.6",
-								"is-data-descriptor": "^0.1.4",
-								"kind-of": "^5.0.0"
+								"is-accessor-descriptor": "0.1.6",
+								"is-data-descriptor": "0.1.4",
+								"kind-of": "5.1.0"
 							}
 						},
 						"kind-of": {
@@ -5548,14 +5548,14 @@
 					"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
 					"dev": true,
 					"requires": {
-						"array-unique": "^0.3.2",
-						"define-property": "^1.0.0",
-						"expand-brackets": "^2.1.4",
-						"extend-shallow": "^2.0.1",
-						"fragment-cache": "^0.2.1",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.1"
+						"array-unique": "0.3.2",
+						"define-property": "1.0.0",
+						"expand-brackets": "2.1.4",
+						"extend-shallow": "2.0.1",
+						"fragment-cache": "0.2.1",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					},
 					"dependencies": {
 						"define-property": {
@@ -5564,7 +5564,7 @@
 							"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 							"dev": true,
 							"requires": {
-								"is-descriptor": "^1.0.0"
+								"is-descriptor": "1.0.2"
 							}
 						},
 						"extend-shallow": {
@@ -5573,7 +5573,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5584,10 +5584,10 @@
 					"integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-number": "^3.0.0",
-						"repeat-string": "^1.6.1",
-						"to-regex-range": "^2.1.0"
+						"extend-shallow": "2.0.1",
+						"is-number": "3.0.0",
+						"repeat-string": "1.6.1",
+						"to-regex-range": "2.1.1"
 					},
 					"dependencies": {
 						"extend-shallow": {
@@ -5596,7 +5596,7 @@
 							"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 							"dev": true,
 							"requires": {
-								"is-extendable": "^0.1.0"
+								"is-extendable": "0.1.1"
 							}
 						}
 					}
@@ -5607,7 +5607,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -5616,7 +5616,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -5625,9 +5625,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-number": {
@@ -5636,7 +5636,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					},
 					"dependencies": {
 						"kind-of": {
@@ -5645,7 +5645,7 @@
 							"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 							"dev": true,
 							"requires": {
-								"is-buffer": "^1.1.5"
+								"is-buffer": "1.1.6"
 							}
 						}
 					}
@@ -5668,19 +5668,19 @@
 					"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
 					"dev": true,
 					"requires": {
-						"arr-diff": "^4.0.0",
-						"array-unique": "^0.3.2",
-						"braces": "^2.3.1",
-						"define-property": "^2.0.2",
-						"extend-shallow": "^3.0.2",
-						"extglob": "^2.0.4",
-						"fragment-cache": "^0.2.1",
-						"kind-of": "^6.0.2",
-						"nanomatch": "^1.2.9",
-						"object.pick": "^1.3.0",
-						"regex-not": "^1.0.0",
-						"snapdragon": "^0.8.1",
-						"to-regex": "^3.0.2"
+						"arr-diff": "4.0.0",
+						"array-unique": "0.3.2",
+						"braces": "2.3.2",
+						"define-property": "2.0.2",
+						"extend-shallow": "3.0.2",
+						"extglob": "2.0.4",
+						"fragment-cache": "0.2.1",
+						"kind-of": "6.0.2",
+						"nanomatch": "1.2.13",
+						"object.pick": "1.3.0",
+						"regex-not": "1.0.2",
+						"snapdragon": "0.8.2",
+						"to-regex": "3.0.2"
 					}
 				},
 				"minimist": {
@@ -5721,10 +5721,10 @@
 			"integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
+				"extend-shallow": "2.0.1",
+				"is-extendable": "0.1.1",
+				"is-plain-object": "2.0.4",
+				"split-string": "3.1.0"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -5733,7 +5733,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -5744,7 +5744,7 @@
 			"integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
 			"dev": true,
 			"requires": {
-				"shebang-regex": "^1.0.0"
+				"shebang-regex": "1.0.0"
 			}
 		},
 		"shebang-regex": {
@@ -5759,10 +5759,10 @@
 			"integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
 			"dev": true,
 			"requires": {
-				"array-filter": "~0.0.0",
-				"array-map": "~0.0.0",
-				"array-reduce": "~0.0.0",
-				"jsonify": "~0.0.0"
+				"array-filter": "0.0.1",
+				"array-map": "0.0.0",
+				"array-reduce": "0.0.0",
+				"jsonify": "0.0.0"
 			}
 		},
 		"shellwords": {
@@ -5782,7 +5782,7 @@
 			"resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
 			"integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
 			"requires": {
-				"is-arrayish": "^0.3.1"
+				"is-arrayish": "0.3.2"
 			},
 			"dependencies": {
 				"is-arrayish": {
@@ -5816,14 +5816,14 @@
 			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
 			"dev": true,
 			"requires": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
+				"base": "0.11.2",
+				"debug": "2.6.9",
+				"define-property": "0.2.5",
+				"extend-shallow": "2.0.1",
+				"map-cache": "0.2.2",
+				"source-map": "0.5.7",
+				"source-map-resolve": "0.5.2",
+				"use": "3.1.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5832,7 +5832,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				},
 				"extend-shallow": {
@@ -5841,7 +5841,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				}
 			}
@@ -5852,9 +5852,9 @@
 			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
+				"define-property": "1.0.0",
+				"isobject": "3.0.1",
+				"snapdragon-util": "3.0.1"
 			},
 			"dependencies": {
 				"define-property": {
@@ -5863,7 +5863,7 @@
 					"integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^1.0.0"
+						"is-descriptor": "1.0.2"
 					}
 				},
 				"is-accessor-descriptor": {
@@ -5872,7 +5872,7 @@
 					"integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-data-descriptor": {
@@ -5881,7 +5881,7 @@
 					"integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
 					"dev": true,
 					"requires": {
-						"kind-of": "^6.0.0"
+						"kind-of": "6.0.2"
 					}
 				},
 				"is-descriptor": {
@@ -5890,9 +5890,9 @@
 					"integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
 					"dev": true,
 					"requires": {
-						"is-accessor-descriptor": "^1.0.0",
-						"is-data-descriptor": "^1.0.0",
-						"kind-of": "^6.0.2"
+						"is-accessor-descriptor": "1.0.0",
+						"is-data-descriptor": "1.0.0",
+						"kind-of": "6.0.2"
 					}
 				},
 				"isobject": {
@@ -5915,7 +5915,7 @@
 			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.2.0"
+				"kind-of": "3.2.2"
 			}
 		},
 		"source-map": {
@@ -5930,11 +5930,11 @@
 			"integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
 			"dev": true,
 			"requires": {
-				"atob": "^2.1.1",
-				"decode-uri-component": "^0.2.0",
-				"resolve-url": "^0.2.1",
-				"source-map-url": "^0.4.0",
-				"urix": "^0.1.0"
+				"atob": "2.1.2",
+				"decode-uri-component": "0.2.0",
+				"resolve-url": "0.2.1",
+				"source-map-url": "0.4.0",
+				"urix": "0.1.0"
 			}
 		},
 		"source-map-support": {
@@ -5943,7 +5943,7 @@
 			"integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
 			"dev": true,
 			"requires": {
-				"source-map": "^0.5.6"
+				"source-map": "0.5.7"
 			}
 		},
 		"source-map-url": {
@@ -5958,8 +5958,8 @@
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"dev": true,
 			"requires": {
-				"spdx-expression-parse": "^3.0.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-expression-parse": "3.0.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -5974,8 +5974,8 @@
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"dev": true,
 			"requires": {
-				"spdx-exceptions": "^2.1.0",
-				"spdx-license-ids": "^3.0.0"
+				"spdx-exceptions": "2.1.0",
+				"spdx-license-ids": "3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -5990,7 +5990,7 @@
 			"integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
 			"dev": true,
 			"requires": {
-				"through": "2"
+				"through": "2.3.8"
 			}
 		},
 		"split-string": {
@@ -5999,7 +5999,7 @@
 			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
 			"dev": true,
 			"requires": {
-				"extend-shallow": "^3.0.0"
+				"extend-shallow": "3.0.2"
 			}
 		},
 		"sprintf-js": {
@@ -6014,15 +6014,15 @@
 			"integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
 			"dev": true,
 			"requires": {
-				"asn1": "~0.2.3",
-				"assert-plus": "^1.0.0",
-				"bcrypt-pbkdf": "^1.0.0",
-				"dashdash": "^1.12.0",
-				"ecc-jsbn": "~0.1.1",
-				"getpass": "^0.1.1",
-				"jsbn": "~0.1.0",
-				"safer-buffer": "^2.0.2",
-				"tweetnacl": "~0.14.0"
+				"asn1": "0.2.4",
+				"assert-plus": "1.0.0",
+				"bcrypt-pbkdf": "1.0.2",
+				"dashdash": "1.14.1",
+				"ecc-jsbn": "0.1.2",
+				"getpass": "0.1.7",
+				"jsbn": "0.1.1",
+				"safer-buffer": "2.1.2",
+				"tweetnacl": "0.14.5"
 			}
 		},
 		"stack-trace": {
@@ -6048,8 +6048,8 @@
 			"integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
 			"dev": true,
 			"requires": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
+				"define-property": "0.2.5",
+				"object-copy": "0.1.0"
 			},
 			"dependencies": {
 				"define-property": {
@@ -6058,7 +6058,7 @@
 					"integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
 					"dev": true,
 					"requires": {
-						"is-descriptor": "^0.1.0"
+						"is-descriptor": "0.1.6"
 					}
 				}
 			}
@@ -6075,7 +6075,7 @@
 			"integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
 			"dev": true,
 			"requires": {
-				"duplexer": "~0.1.1"
+				"duplexer": "0.1.1"
 			}
 		},
 		"string-argv": {
@@ -6090,8 +6090,8 @@
 			"integrity": "sha1-1A27aGo6zpYMHP/KVivyxF+DY+0=",
 			"dev": true,
 			"requires": {
-				"astral-regex": "^1.0.0",
-				"strip-ansi": "^4.0.0"
+				"astral-regex": "1.0.0",
+				"strip-ansi": "4.0.0"
 			}
 		},
 		"string-width": {
@@ -6100,8 +6100,8 @@
 			"integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
 			"dev": true,
 			"requires": {
-				"is-fullwidth-code-point": "^2.0.0",
-				"strip-ansi": "^4.0.0"
+				"is-fullwidth-code-point": "2.0.0",
+				"strip-ansi": "4.0.0"
 			}
 		},
 		"string.prototype.padend": {
@@ -6110,9 +6110,9 @@
 			"integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"es-abstract": "^1.4.3",
-				"function-bind": "^1.0.2"
+				"define-properties": "1.1.2",
+				"es-abstract": "1.12.0",
+				"function-bind": "1.1.1"
 			}
 		},
 		"string_decoder": {
@@ -6120,7 +6120,7 @@
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"stringify-object": {
@@ -6129,9 +6129,9 @@
 			"integrity": "sha512-rHqiFh1elqCQ9WPLIC8I0Q/g/wj5J1eMkyoiD6eoQApWHP0FtlK7rqnhmabL5VUY9JQCcqwwvlOaSuutekgyrw==",
 			"dev": true,
 			"requires": {
-				"get-own-enumerable-property-symbols": "^3.0.0",
-				"is-obj": "^1.0.1",
-				"is-regexp": "^1.0.0"
+				"get-own-enumerable-property-symbols": "3.0.0",
+				"is-obj": "1.0.1",
+				"is-regexp": "1.0.0"
 			}
 		},
 		"strip-ansi": {
@@ -6140,7 +6140,7 @@
 			"integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^3.0.0"
+				"ansi-regex": "3.0.0"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -6193,11 +6193,11 @@
 			"integrity": "sha512-SYbXgY64PT+4GAL2ocI3HwPa4Q4TBKm0cwAVeKOt/Aoc0gSpNRjJX8w0pA1LMKZ3LBmd8pYBqApFNQLII9kavA==",
 			"dev": true,
 			"requires": {
-				"arrify": "^1.0.1",
-				"micromatch": "^2.3.11",
-				"object-assign": "^4.1.0",
-				"read-pkg-up": "^1.0.1",
-				"require-main-filename": "^1.0.1"
+				"arrify": "1.0.1",
+				"micromatch": "2.3.11",
+				"object-assign": "4.1.1",
+				"read-pkg-up": "1.0.1",
+				"require-main-filename": "1.0.1"
 			}
 		},
 		"text-hex": {
@@ -6235,7 +6235,7 @@
 			"integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
 			"dev": true,
 			"requires": {
-				"kind-of": "^3.0.2"
+				"kind-of": "3.2.2"
 			}
 		},
 		"to-regex": {
@@ -6244,10 +6244,10 @@
 			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
 			"dev": true,
 			"requires": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
+				"define-property": "2.0.2",
+				"extend-shallow": "3.0.2",
+				"regex-not": "1.0.2",
+				"safe-regex": "1.1.0"
 			}
 		},
 		"to-regex-range": {
@@ -6256,8 +6256,8 @@
 			"integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
 			"dev": true,
 			"requires": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
+				"is-number": "3.0.0",
+				"repeat-string": "1.6.1"
 			},
 			"dependencies": {
 				"is-number": {
@@ -6266,7 +6266,7 @@
 					"integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
 					"dev": true,
 					"requires": {
-						"kind-of": "^3.0.2"
+						"kind-of": "3.2.2"
 					}
 				}
 			}
@@ -6277,8 +6277,8 @@
 			"integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
 			"dev": true,
 			"requires": {
-				"psl": "^1.1.24",
-				"punycode": "^1.4.1"
+				"psl": "1.1.29",
+				"punycode": "1.4.1"
 			},
 			"dependencies": {
 				"punycode": {
@@ -6295,7 +6295,7 @@
 			"integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
 			"dev": true,
 			"requires": {
-				"punycode": "^2.1.0"
+				"punycode": "2.1.1"
 			}
 		},
 		"trim-right": {
@@ -6315,14 +6315,14 @@
 			"integrity": "sha512-oV/wBwGUS7olSk/9yWMiSIJWbz5xO4zhftnY3gwv6s4SMg6WHF1m8XZNBvQOKQRiTAexZ9754Z13dxBq3Zgssw==",
 			"dev": true,
 			"requires": {
-				"bs-logger": "0.x",
-				"buffer-from": "1.x",
-				"fast-json-stable-stringify": "2.x",
-				"json5": "2.x",
-				"make-error": "1.x",
-				"mkdirp": "0.x",
-				"semver": "^5.5",
-				"yargs-parser": "10.x"
+				"bs-logger": "0.2.5",
+				"buffer-from": "1.1.1",
+				"fast-json-stable-stringify": "2.0.0",
+				"json5": "2.1.0",
+				"make-error": "1.3.5",
+				"mkdirp": "0.5.1",
+				"semver": "5.5.0",
+				"yargs-parser": "10.1.0"
 			},
 			"dependencies": {
 				"json5": {
@@ -6331,7 +6331,7 @@
 					"integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
 					"dev": true,
 					"requires": {
-						"minimist": "^1.2.0"
+						"minimist": "1.2.0"
 					}
 				},
 				"minimist": {
@@ -6346,7 +6346,7 @@
 					"integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
 					"dev": true,
 					"requires": {
-						"camelcase": "^4.1.0"
+						"camelcase": "4.1.0"
 					}
 				}
 			}
@@ -6357,7 +6357,7 @@
 			"integrity": "sha512-chcKw0sTApwJxTyKhzbWxI4BTUJ6RStZKUVh2/mfwYqFS09PYy5pvdXZwG35QSkqT5pkdXZlYKBX196RRvEZdQ==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.5"
+				"lodash": "4.17.11"
 			}
 		},
 		"tslib": {
@@ -6372,18 +6372,18 @@
 			"integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
 			"dev": true,
 			"requires": {
-				"babel-code-frame": "^6.22.0",
-				"builtin-modules": "^1.1.1",
-				"chalk": "^2.3.0",
-				"commander": "^2.12.1",
-				"diff": "^3.2.0",
-				"glob": "^7.1.1",
-				"js-yaml": "^3.7.0",
-				"minimatch": "^3.0.4",
-				"resolve": "^1.3.2",
-				"semver": "^5.3.0",
-				"tslib": "^1.8.0",
-				"tsutils": "^2.27.2"
+				"babel-code-frame": "6.26.0",
+				"builtin-modules": "1.1.1",
+				"chalk": "2.3.2",
+				"commander": "2.17.1",
+				"diff": "3.5.0",
+				"glob": "7.1.3",
+				"js-yaml": "3.12.0",
+				"minimatch": "3.0.4",
+				"resolve": "1.8.1",
+				"semver": "5.5.0",
+				"tslib": "1.9.3",
+				"tsutils": "2.29.0"
 			},
 			"dependencies": {
 				"resolve": {
@@ -6392,7 +6392,7 @@
 					"integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
 					"dev": true,
 					"requires": {
-						"path-parse": "^1.0.5"
+						"path-parse": "1.0.6"
 					}
 				}
 			}
@@ -6403,7 +6403,7 @@
 			"integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
 			"dev": true,
 			"requires": {
-				"tslib": "^1.8.1"
+				"tslib": "1.9.3"
 			}
 		},
 		"tunnel-agent": {
@@ -6412,7 +6412,7 @@
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.0.1"
+				"safe-buffer": "5.1.2"
 			}
 		},
 		"tweetnacl": {
@@ -6427,7 +6427,7 @@
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "1.1.2"
 			}
 		},
 		"typescript": {
@@ -6443,8 +6443,8 @@
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.17.1",
-				"source-map": "~0.6.1"
+				"commander": "2.17.1",
+				"source-map": "0.6.1"
 			},
 			"dependencies": {
 				"source-map": {
@@ -6462,10 +6462,10 @@
 			"integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
 			"dev": true,
 			"requires": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^0.4.3"
+				"arr-union": "3.1.0",
+				"get-value": "2.0.6",
+				"is-extendable": "0.1.1",
+				"set-value": "0.4.3"
 			},
 			"dependencies": {
 				"extend-shallow": {
@@ -6474,7 +6474,7 @@
 					"integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
 					"dev": true,
 					"requires": {
-						"is-extendable": "^0.1.0"
+						"is-extendable": "0.1.1"
 					}
 				},
 				"set-value": {
@@ -6483,10 +6483,10 @@
 					"integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
 					"dev": true,
 					"requires": {
-						"extend-shallow": "^2.0.1",
-						"is-extendable": "^0.1.1",
-						"is-plain-object": "^2.0.1",
-						"to-object-path": "^0.3.0"
+						"extend-shallow": "2.0.1",
+						"is-extendable": "0.1.1",
+						"is-plain-object": "2.0.4",
+						"to-object-path": "0.3.0"
 					}
 				}
 			}
@@ -6497,8 +6497,8 @@
 			"integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
 			"dev": true,
 			"requires": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
+				"has-value": "0.3.1",
+				"isobject": "3.0.1"
 			},
 			"dependencies": {
 				"has-value": {
@@ -6507,9 +6507,9 @@
 					"integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
 					"dev": true,
 					"requires": {
-						"get-value": "^2.0.3",
-						"has-values": "^0.1.4",
-						"isobject": "^2.0.0"
+						"get-value": "2.0.6",
+						"has-values": "0.1.4",
+						"isobject": "2.1.0"
 					},
 					"dependencies": {
 						"isobject": {
@@ -6560,8 +6560,8 @@
 			"integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.2",
-				"object.getownpropertydescriptors": "^2.0.3"
+				"define-properties": "1.1.2",
+				"object.getownpropertydescriptors": "2.0.3"
 			}
 		},
 		"uuid": {
@@ -6576,8 +6576,8 @@
 			"integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
 			"dev": true,
 			"requires": {
-				"spdx-correct": "^3.0.0",
-				"spdx-expression-parse": "^3.0.0"
+				"spdx-correct": "3.0.0",
+				"spdx-expression-parse": "3.0.0"
 			}
 		},
 		"verror": {
@@ -6586,9 +6586,9 @@
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
 			"dev": true,
 			"requires": {
-				"assert-plus": "^1.0.0",
+				"assert-plus": "1.0.0",
 				"core-util-is": "1.0.2",
-				"extsprintf": "^1.2.0"
+				"extsprintf": "1.3.0"
 			}
 		},
 		"vscode-jsonrpc": {
@@ -6602,7 +6602,7 @@
 			"integrity": "sha512-RYUKn0DgHTFcS8kS4VaNCjNMaQXYqiXdN9bKrFjXzu5RPKfjIYcoh47oVWwZj4L3R/DPB0Se7HPaDatvYY2XgQ==",
 			"requires": {
 				"vscode-languageserver-protocol": "3.5.1",
-				"vscode-uri": "^1.0.1"
+				"vscode-uri": "1.0.6"
 			}
 		},
 		"vscode-languageserver-protocol": {
@@ -6630,7 +6630,7 @@
 			"integrity": "sha1-gqwr/2PZUOqeMYmlimViX+3xkEU=",
 			"dev": true,
 			"requires": {
-				"browser-process-hrtime": "^0.1.2"
+				"browser-process-hrtime": "0.1.3"
 			}
 		},
 		"walker": {
@@ -6639,7 +6639,7 @@
 			"integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
 			"dev": true,
 			"requires": {
-				"makeerror": "1.0.x"
+				"makeerror": "1.0.11"
 			}
 		},
 		"watch": {
@@ -6648,8 +6648,8 @@
 			"integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
 			"dev": true,
 			"requires": {
-				"exec-sh": "^0.2.0",
-				"minimist": "^1.2.0"
+				"exec-sh": "0.2.2",
+				"minimist": "1.2.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -6687,9 +6687,9 @@
 			"integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
 			"dev": true,
 			"requires": {
-				"lodash.sortby": "^4.7.0",
-				"tr46": "^1.0.1",
-				"webidl-conversions": "^4.0.2"
+				"lodash.sortby": "4.7.0",
+				"tr46": "1.0.1",
+				"webidl-conversions": "4.0.2"
 			}
 		},
 		"which": {
@@ -6698,7 +6698,7 @@
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"dev": true,
 			"requires": {
-				"isexe": "^2.0.0"
+				"isexe": "2.0.0"
 			}
 		},
 		"which-module": {
@@ -6712,15 +6712,15 @@
 			"resolved": "https://registry.npmjs.org/winston/-/winston-3.1.0.tgz",
 			"integrity": "sha512-FsQfEE+8YIEeuZEYhHDk5cILo1HOcWkGwvoidLrDgPog0r4bser1lEIOco2dN9zpDJ1M88hfDgZvxe5z4xNcwg==",
 			"requires": {
-				"async": "^2.6.0",
-				"diagnostics": "^1.1.1",
-				"is-stream": "^1.1.0",
-				"logform": "^1.9.1",
+				"async": "2.6.1",
+				"diagnostics": "1.1.1",
+				"is-stream": "1.1.0",
+				"logform": "1.10.0",
 				"one-time": "0.0.4",
-				"readable-stream": "^2.3.6",
-				"stack-trace": "0.0.x",
-				"triple-beam": "^1.3.0",
-				"winston-transport": "^4.2.0"
+				"readable-stream": "2.3.6",
+				"stack-trace": "0.0.10",
+				"triple-beam": "1.3.0",
+				"winston-transport": "4.2.0"
 			}
 		},
 		"winston-transport": {
@@ -6728,8 +6728,8 @@
 			"resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.2.0.tgz",
 			"integrity": "sha512-0R1bvFqxSlK/ZKTH86nymOuKv/cT1PQBMuDdA7k7f0S9fM44dNH6bXnuxwXPrN8lefJgtZq08BKdyZ0DZIy/rg==",
 			"requires": {
-				"readable-stream": "^2.3.6",
-				"triple-beam": "^1.2.0"
+				"readable-stream": "2.3.6",
+				"triple-beam": "1.3.0"
 			}
 		},
 		"wordwrap": {
@@ -6744,8 +6744,8 @@
 			"integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
 			"dev": true,
 			"requires": {
-				"string-width": "^1.0.1",
-				"strip-ansi": "^3.0.1"
+				"string-width": "1.0.2",
+				"strip-ansi": "3.0.1"
 			},
 			"dependencies": {
 				"is-fullwidth-code-point": {
@@ -6754,7 +6754,7 @@
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
 					"requires": {
-						"number-is-nan": "^1.0.0"
+						"number-is-nan": "1.0.1"
 					}
 				},
 				"string-width": {
@@ -6763,9 +6763,9 @@
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
 					"requires": {
-						"code-point-at": "^1.0.0",
-						"is-fullwidth-code-point": "^1.0.0",
-						"strip-ansi": "^3.0.0"
+						"code-point-at": "1.1.0",
+						"is-fullwidth-code-point": "1.0.0",
+						"strip-ansi": "3.0.1"
 					}
 				},
 				"strip-ansi": {
@@ -6774,7 +6774,7 @@
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "2.1.1"
 					}
 				}
 			}
@@ -6791,9 +6791,9 @@
 			"integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
 			"dev": true,
 			"requires": {
-				"graceful-fs": "^4.1.11",
-				"imurmurhash": "^0.1.4",
-				"signal-exit": "^3.0.2"
+				"graceful-fs": "4.1.11",
+				"imurmurhash": "0.1.4",
+				"signal-exit": "3.0.2"
 			}
 		},
 		"ws": {
@@ -6802,7 +6802,7 @@
 			"integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
 			"dev": true,
 			"requires": {
-				"async-limiter": "~1.0.0"
+				"async-limiter": "1.0.0"
 			}
 		},
 		"xml-name-validator": {
@@ -6829,18 +6829,18 @@
 			"integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
 			"dev": true,
 			"requires": {
-				"cliui": "^4.0.0",
-				"decamelize": "^1.1.1",
-				"find-up": "^2.1.0",
-				"get-caller-file": "^1.0.1",
-				"os-locale": "^2.0.0",
-				"require-directory": "^2.1.1",
-				"require-main-filename": "^1.0.1",
-				"set-blocking": "^2.0.0",
-				"string-width": "^2.0.0",
-				"which-module": "^2.0.0",
-				"y18n": "^3.2.1",
-				"yargs-parser": "^9.0.2"
+				"cliui": "4.1.0",
+				"decamelize": "1.2.0",
+				"find-up": "2.1.0",
+				"get-caller-file": "1.0.3",
+				"os-locale": "2.1.0",
+				"require-directory": "2.1.1",
+				"require-main-filename": "1.0.1",
+				"set-blocking": "2.0.0",
+				"string-width": "2.1.1",
+				"which-module": "2.0.0",
+				"y18n": "3.2.1",
+				"yargs-parser": "9.0.2"
 			}
 		},
 		"yargs-parser": {
@@ -6849,7 +6849,7 @@
 			"integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
 			"dev": true,
 			"requires": {
-				"camelcase": "^4.1.0"
+				"camelcase": "4.1.0"
 			}
 		}
 	}


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG.md file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have read the CONTRIBUTING.md document.
-->

### Summary
This PR adds support for Qiskit Terra v0.7, as required in #60. 

Also, as decided by the team and documented in the Support Decision Record (SDR) 1, in the future we will maintain only the current version of Qiskit Terra and a previous one. According to the decision, this PR drops the support for Qiskit Terra v0.5

### Details and comments
Appart of some changes in the API, the support of Terra v0.7 implied the need of [ignoring the warnings raised by the `marshmallow` module](https://github.com/Qiskit/qiskit-terra/commit/11b69e4e620d02994b95a5fad925833011202342#diff-1cbb089c669bc3c7d5b9189badd019f8R56). As discussed with other members of the Qiskit team, this warning will be ignored/solved in the next version v0.8. For now, we need to filter the warning `ChangedInMarshmallow3Warning` using new code in our Qiskit-related scripts or using filters for warnings when executing some scripts (using `python -W ignore:"strict=False is not recommended. In marshmallow 3.0"` as the way of executing the users' Python scripts from the extension).
