### PR TITLE
Testing the migration of CI from travis-ci.org to travis-ci.com and modifying the badge source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Qiskit VSCode Extension
 
 [![status](https://joss.theoj.org/papers/7687665c24744f6cc3aa30666a70b219/status.svg)](https://joss.theoj.org/papers/7687665c24744f6cc3aa30666a70b219)
-[![Build Status](https://www.travis-ci.org/Qiskit/qiskit-vscode.svg?branch=master)](https://www.travis-ci.org/Qiskit/qiskit-vscode)
+[![Build Status](https://www.travis-ci.com/Qiskit/qiskit-vscode.svg?branch=master)](https://www.travis-ci.com/Qiskit/qiskit-vscode)
 
 > Simplifying Qiskit to make developing quantum circuits and applications faster.
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG.md file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have read the CONTRIBUTING.md document.
-->

### Summary
Recently, the Qiskit repos have been migrated from travis-ci.org to travis-ci.com. This PR tests the build in travis-ci.com and modifies the URL of the badge included in the README.


### Details and comments


