### PR TITLE
Adding IBMQuantumExperience dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### 🐛 Fixed
 
+-   Adding IBMQuantumExperience dependency to solve issue #81 and others alike ([#82](https://github.com/Qiskit/qiskit-vscode/pull/82) by [@cbjuan](https://github.com/cbjuan))
+
 ### ✏️ Changed
 
 ### 👾 Security

--- a/client/package.json
+++ b/client/package.json
@@ -93,7 +93,8 @@
 					"default": {
 						"qiskit": "0.6.0",
 						"qiskit-aqua": "0.4.0",
-						"qiskit-chemistry": "0.4.2"
+						"qiskit-chemistry": "0.4.2",
+						"IBMQuantumExperience": "2.0.4"
 					},
 					"description": "Qiskit and libraries related to run code"
 				},


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG.md file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have read the CONTRIBUTING.md document.
-->

### Summary
This PR should fix issue #81. The dependency `IBMQuantumExperience` was missing from required packages, so people who had not installed it previously experience errors when using the scripts which rely on `QiskitTools.py`.


### Details and comments


