### PR TITLE
Typo fix in the Qiskit Code Assistant disclaimer handler:

### DIFF
--- a/src/commands/acceptDisclaimer.ts
+++ b/src/commands/acceptDisclaimer.ts
@@ -61,7 +61,7 @@ async function handler(model: ModelInfo): Promise<void> {
         disclaimerState.panel?.dispose();
         return;
       default:
-        console.log("Unknown dislaimer webview message: ", m);
+        console.log("Unknown disclaimer webview message: ", m);
     }
   });
   disclaimerState.panel.onDidDispose(() => {


### PR DESCRIPTION
Description

This PR fixes a minor typo in the disclaimer-acceptance command handler of the Qiskit Code Assistant extension.
Previously, the log message for unrecognized disclaimer webview messages printed "Unknown dislaimer webview message".
This typo has been corrected to "Unknown disclaimer webview message".

This improves readability and consistency in developer logs when debugging extension behavior.


Type of change

 Bug fix (non-breaking change which fixes a typo in log output)

How Has This Been Tested?

Verified manually by running the extension and sending an unexpected message from the disclaimer webview.

Confirmed the console output now correctly shows "Unknown disclaimer webview message" instead of the misspelled "dislaimer".

Test Configuration:
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
