### PR TITLE
Fix service API singleton refresh

### DIFF
--- a/src/commands/selectModel.ts
+++ b/src/commands/selectModel.ts
@@ -17,6 +17,16 @@ export function setAsCurrentModel(model: ModelInfo): void {
   }
 }
 
+/**
+ * Invalidates the current model selection and clears the models list.
+ * Call this when the service API changes to prevent "model not found" errors.
+ */
+export function invalidateCurrentModel(): void {
+  currentModel = undefined;
+  modelsList = [];
+  setDefaultStatus();
+}
+
 export async function initModels(context: ExtensionContext | null): Promise<void> {
   if (!context) return;
 

--- a/src/services/common.ts
+++ b/src/services/common.ts
@@ -2,19 +2,21 @@ import * as vscode from "vscode";
 import CodeAssistantService from "./codeAssistant"
 import OpenAIService from "./openAI"
 import ServiceAPI from "./serviceApi";
+import { invalidateCurrentModel } from "../commands/selectModel";
 
 let activeService: ServiceAPI | undefined;
 let lastServiceUrl: string | undefined;
 let initializationPromise: Promise<ServiceAPI> | undefined;
 
 /**
- * Invalidates the cached service API instance.
+ * Invalidates the cached service API instance and clears the current model selection.
  * Call this when service URL changes or on errors that require re-initialization.
  */
 export function invalidateServiceApi(): void {
   activeService = undefined;
   lastServiceUrl = undefined;
   initializationPromise = undefined;
+  invalidateCurrentModel();
 }
 
 export async function getServiceApi(): Promise<ServiceAPI> {

--- a/src/test/suite/common.test.ts
+++ b/src/test/suite/common.test.ts
@@ -6,6 +6,7 @@ import ServiceAPI from '../../services/serviceApi';
 import CodeAssistantService from '../../services/codeAssistant';
 import OpenAIService from '../../services/openAI';
 import { createMockResponse, createMockConfiguration } from '../mocks/vscode.mock';
+import * as selectModel from '../../commands/selectModel';
 
 suite('Common Service API Singleton Test Suite', () => {
   let workspaceStub: sinon.SinonStub;
@@ -66,6 +67,20 @@ suite('Common Service API Singleton Test Suite', () => {
 
       // Verify runFetch was called twice (once for each initialization)
       expect(runFetchStub.callCount).to.equal(2);
+    });
+
+    test('should clear current model selection when invalidating service API', () => {
+      // Stub invalidateCurrentModel
+      const invalidateCurrentModelStub = sinon.stub(selectModel, 'invalidateCurrentModel');
+
+      // Call invalidateServiceApi
+      invalidateServiceApi();
+
+      // Verify invalidateCurrentModel was called
+      expect(invalidateCurrentModelStub.calledOnce).to.be.true;
+
+      // Restore stub
+      invalidateCurrentModelStub.restore();
     });
   });
 


### PR DESCRIPTION
# Description

Fixes the bug about service API Singleton never refreshes. When changing the service URL, it gets automatically refreshed.

## Linked Issue(s)

Fixes #136 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tests added

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
